### PR TITLE
fix(repository) handle cases where empty collections produce invalid DynamoDB IN () expressions

### DIFF
--- a/src/main/java/pl/commercelink/orders/OrderItemsRepository.java
+++ b/src/main/java/pl/commercelink/orders/OrderItemsRepository.java
@@ -62,6 +62,9 @@ public class OrderItemsRepository extends DynamoDbRepository<OrderItem> {
     }
 
     public List<OrderItem> findByOrderIdAndStatuses(String orderId, List<FulfilmentStatus> statuses) {
+        if (statuses == null || statuses.isEmpty()) {
+            return List.of();
+        }
         Map<String, AttributeValue> eav = new HashMap<>();
         eav.put(":orderId", new AttributeValue().withS(orderId));
 
@@ -77,6 +80,9 @@ public class OrderItemsRepository extends DynamoDbRepository<OrderItem> {
     }
 
     public List<String> findByDeliveryIdAndStatuses(String deliveryId, List<FulfilmentStatus> statuses) {
+        if (statuses == null || statuses.isEmpty()) {
+            return List.of();
+        }
         Map<String, AttributeValue> eav = new HashMap<>();
         eav.put(":deliveryId", new AttributeValue().withS(deliveryId));
 
@@ -107,6 +113,9 @@ public class OrderItemsRepository extends DynamoDbRepository<OrderItem> {
     }
 
     public OrderItem findBySerialNoAndStatuses(String serialNo, List<FulfilmentStatus> statuses) {
+        if (statuses == null || statuses.isEmpty()) {
+            return null;
+        }
         Map<String, AttributeValue> eav = new HashMap<>();
         eav.put(":serialNo", new AttributeValue().withS(serialNo));
 

--- a/src/main/java/pl/commercelink/warehouse/builtin/WarehouseRepository.java
+++ b/src/main/java/pl/commercelink/warehouse/builtin/WarehouseRepository.java
@@ -171,6 +171,9 @@ class WarehouseRepository extends DynamoDbRepository<WarehouseItem> {
     }
 
     List<WarehouseItem> findAllAvailableByMfns(String storeId, Collection<String> mfns) {
+        if (mfns == null || mfns.isEmpty()) {
+            return List.of();
+        }
         Map<String, AttributeValue> eav = new HashMap<>();
         Map<String, String> ean = new HashMap<>();
         eav.put(":storeId", new AttributeValue().withS(storeId));
@@ -201,6 +204,9 @@ class WarehouseRepository extends DynamoDbRepository<WarehouseItem> {
     }
 
     List<WarehouseItem> findAllByMfns(String storeId, Collection<String> mfns) {
+        if (mfns == null || mfns.isEmpty()) {
+            return List.of();
+        }
         Map<String, AttributeValue> eav = new HashMap<>();
         eav.put(":storeId", new AttributeValue().withS(storeId));
 


### PR DESCRIPTION


## Description
  - Fixed Invalid FilterExpression DynamoDB errors caused by empty IN () clauses when collections passed to query methods are empty
  - The immediate issue: looking up a product by EAN triggers a warehouse inventory check by MFN codes, but when the inventory key has no MFN codes, the query builds mfn IN () which is invalid DynamoDB syntax
  - Added early-return guards to 5 repository methods across 2 files:
    - WarehouseRepository.findAllAvailableByMfns — empty mfns
    - WarehouseRepository.findAllByMfns — empty mfns
    - OrderItemsRepository.findByOrderIdAndStatuses — empty statuses
    - OrderItemsRepository.findByDeliveryIdAndStatuses — empty statuses
    - OrderItemsRepository.findBySerialNoAndStatuses — empty statuses
  - 2 other similar methods (OrdersRepository, ProductRepository) already had proper guards

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] New provider implementation
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other: ___

## Checklist

- [ ] `mvn clean compile` passes
- [ ] Existing tests pass (`mvn test`)
- [ ] New tests added (if applicable)
- [ ] README updated (if applicable)
- [ ] No credentials, API keys, or secrets in committed files

### Provider-specific (if applicable)

- [ ] Provider interface implemented
- [ ] Descriptor registered via `META-INF/services/`
- [ ] Configuration fields defined in descriptor
- [ ] `README.md` with required configuration documented
- [ ] `LICENSE` file included

### DynamoDB changes (if applicable)

- [ ] Migration path considered for existing data
- [ ] Backward-compatible key lookups added (if range key changed)
- [ ] `DynamoDbSchema.java` updated

## Testing

<!-- How was this tested? LocalStack, unit tests, manual? -->
