### PR TITLE
Bump commercelink-starter to 0.1.8, app to 2026.06.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pl.commercelink</groupId>
     <artifactId>commercelink</artifactId>
-    <version>2026.06.06</version>
+    <version>2026.06.19</version>
     <packaging>jar</packaging>
 
     <parent>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>pl.commercelink</groupId>
             <artifactId>commercelink-starter</artifactId>
-            <version>0.1.6</version>
+            <version>0.1.8</version>
         </dependency>
         <dependency>
             <groupId>pl.commercelink</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pl.commercelink</groupId>
     <artifactId>commercelink</artifactId>
-    <version>2026.06.19</version>
+    <version>2026.06.7</version>
     <packaging>jar</packaging>
 
     <parent>


### PR DESCRIPTION
## Summary

Picks up the \`MessageSourceEnumLocalizer\` fix shipped in starter 0.1.8 (commerce-link/starter#9) and bumps the app version stamp.

In 0.1.6 / 0.1.7, \`resolveLocale\` used reference equality against \`Locale.getDefault()\` to detect "no caller-provided locale" and apply the configured fallback. On JVMs whose default Locale equals the cached \`Locale.ENGLISH\` instance (typical for prod containers running with \`LANG=C.UTF-8\`), an English Locale passed by Spring's resolver or by a caller was silently swapped for the fallback — so English-locale HTTP users would have received Polish strings. 0.1.8 only applies the fallback when no locale was supplied at all; explicit locales (including those equal to the JVM default) are honored.

This branch is off \`main\` (starter 0.1.6 → 0.1.8) — it does not include the open \`feature/product-localization-di-refactor\` PR. Merging both will create a small pom.xml conflict on the starter dependency line.

## Test plan
- [x] \`mvn test -Pdev\` (285/285 PASS against starter 0.1.8 installed locally)
- [ ] CI green on PR once starter 0.1.8 is published to GitHub Packages