### PR TITLE
ci: uruchamiaj testy na PR (Test on PR)

### DIFF
--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -1,0 +1,16 @@
+name: Test on PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: test-on-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  call-shared-workflow:
+    permissions:
+      contents: read
+      packages: read
+    uses: commerce-link/.github/.github/workflows/maven-test.yml@main


### PR DESCRIPTION
Dodaje workflow uruchamiajacy `mvn test` na kazdym PR do `main` (przez shared `maven-test.yml`). Cel: zlapac bledy zalezne od srodowiska CI (np. domyslny locale JVM) zanim trafia na `main`.