### PR TITLE
OrderItem/BasketItem/WarehouseItem now persist category as a string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pl.commercelink</groupId>
     <artifactId>commercelink</artifactId>
-    <version>2026.06.21</version>
+    <version>2026.06.22</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/src/main/java/pl/commercelink/baskets/Basket.java
+++ b/src/main/java/pl/commercelink/baskets/Basket.java
@@ -1,5 +1,7 @@
 package pl.commercelink.baskets;
 
+import pl.commercelink.taxonomy.Categorized;
+
 import com.amazonaws.services.dynamodbv2.datamodeling.*;
 import pl.commercelink.orders.BillingDetails;
 import pl.commercelink.orders.OrderSource;
@@ -8,7 +10,6 @@ import pl.commercelink.orders.fulfilment.FulfilmentType;
 import pl.commercelink.starter.dynamodb.DynamoDbLocalDateTimeConverter;
 import pl.commercelink.stores.DeliveryOption;
 import pl.commercelink.stores.Store;
-import pl.commercelink.taxonomy.ProductCategory;
 import pl.commercelink.taxonomy.UnifiedProductIdentifiers;
 
 import java.time.LocalDateTime;
@@ -109,12 +110,12 @@ public class Basket {
 
     @DynamoDBIgnore
     public List<BasketItem> getBasketItemsForProducts() {
-        return basketItems.stream().filter(i -> !i.hasCategory(ProductCategory.Services)).collect(Collectors.toList());
+        return basketItems.stream().filter(i -> !i.hasCategoryKey(Categorized.SERVICES)).collect(Collectors.toList());
     }
 
     @DynamoDBIgnore
     public List<BasketItem> getBasketItemsForServices() {
-        return basketItems.stream().filter(i -> i.hasCategory(ProductCategory.Services)).collect(Collectors.toList());
+        return basketItems.stream().filter(i -> i.hasCategoryKey(Categorized.SERVICES)).collect(Collectors.toList());
     }
 
     public void setBasketItems(List<BasketItem> basketItems) {
@@ -247,7 +248,7 @@ public class Basket {
     @DynamoDBIgnore
     public Optional<BasketItem> getShippingItem() {
         return basketItems.stream()
-                .filter(i -> i.hasCategory(ProductCategory.Services))
+                .filter(i -> i.hasCategoryKey(Categorized.SERVICES))
                 .filter(BasketItem::isShippingItem)
                 .findFirst();
     }

--- a/src/main/java/pl/commercelink/baskets/Basket.java
+++ b/src/main/java/pl/commercelink/baskets/Basket.java
@@ -1,7 +1,5 @@
 package pl.commercelink.baskets;
 
-import pl.commercelink.taxonomy.Categorized;
-
 import com.amazonaws.services.dynamodbv2.datamodeling.*;
 import pl.commercelink.orders.BillingDetails;
 import pl.commercelink.orders.OrderSource;
@@ -110,12 +108,12 @@ public class Basket {
 
     @DynamoDBIgnore
     public List<BasketItem> getBasketItemsForProducts() {
-        return basketItems.stream().filter(i -> !i.hasCategoryKey(Categorized.SERVICES)).collect(Collectors.toList());
+        return basketItems.stream().filter(i -> i.isProduct()).collect(Collectors.toList());
     }
 
     @DynamoDBIgnore
     public List<BasketItem> getBasketItemsForServices() {
-        return basketItems.stream().filter(i -> i.hasCategoryKey(Categorized.SERVICES)).collect(Collectors.toList());
+        return basketItems.stream().filter(i -> i.isService()).collect(Collectors.toList());
     }
 
     public void setBasketItems(List<BasketItem> basketItems) {
@@ -248,7 +246,7 @@ public class Basket {
     @DynamoDBIgnore
     public Optional<BasketItem> getShippingItem() {
         return basketItems.stream()
-                .filter(i -> i.hasCategoryKey(Categorized.SERVICES))
+                .filter(i -> i.isService())
                 .filter(BasketItem::isShippingItem)
                 .findFirst();
     }

--- a/src/main/java/pl/commercelink/baskets/BasketItem.java
+++ b/src/main/java/pl/commercelink/baskets/BasketItem.java
@@ -60,16 +60,6 @@ public class BasketItem implements Categorized {
         return isNotBlank(name) && isNotBlank(mfn) && category != null && qty > 0 && unitPrice >= 0;
     }
 
-    @DynamoDBIgnore
-    public boolean isProduct() {
-        return !hasCategoryKey(SERVICES);
-    }
-
-    @DynamoDBIgnore
-    public boolean isService() {
-        return hasCategoryKey(SERVICES);
-    }
-
     public String getId() {
         return id;
     }

--- a/src/main/java/pl/commercelink/baskets/BasketItem.java
+++ b/src/main/java/pl/commercelink/baskets/BasketItem.java
@@ -3,9 +3,9 @@ package pl.commercelink.baskets;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBDocument;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConvertedEnum;
 import pl.commercelink.inventory.MatchedInventory;
 import pl.commercelink.pricelist.AvailabilityAndPrice;
+import pl.commercelink.taxonomy.Categorized;
 import pl.commercelink.taxonomy.ProductCategory;
 import pl.commercelink.starter.util.UniqueIdentifierGenerator;
 import pl.commercelink.inventory.supplier.api.Taxonomy;
@@ -13,7 +13,7 @@ import pl.commercelink.inventory.supplier.api.Taxonomy;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @DynamoDBDocument
-public class BasketItem {
+public class BasketItem implements Categorized {
 
     public static final String SHIPPING_MFN_CODE = "Shipping";
 
@@ -23,9 +23,7 @@ public class BasketItem {
     private  String name;
     @DynamoDBAttribute(attributeName = "mfn")
     private String mfn;
-    @DynamoDBAttribute(attributeName = "category")
-    @DynamoDBTypeConvertedEnum
-    private  ProductCategory category;
+    private String category;
     @DynamoDBAttribute(attributeName = "qty")
     private  long qty;
     @DynamoDBAttribute(attributeName = "unitPrice")
@@ -48,7 +46,7 @@ public class BasketItem {
         this.id = id;
         this.name = name;
         this.mfn = mfn;
-        this.category = category;
+        this.category = category == null ? null : category.name();
         this.qty = qty;
         this.unitPrice = unitPrice;
         this.unitCost = unitCost;
@@ -64,12 +62,12 @@ public class BasketItem {
 
     @DynamoDBIgnore
     public boolean isProduct() {
-        return category != ProductCategory.Services;
+        return !hasCategoryKey(SERVICES);
     }
 
     @DynamoDBIgnore
     public boolean isService() {
-        return category == ProductCategory.Services;
+        return hasCategoryKey(SERVICES);
     }
 
     public String getId() {
@@ -80,8 +78,13 @@ public class BasketItem {
         return name;
     }
 
-    public ProductCategory getCategory() {
+    @DynamoDBAttribute(attributeName = "category")
+    public String getCategoryKey() {
         return category;
+    }
+
+    public void setCategoryKey(String category) {
+        this.category = category;
     }
 
     public double getUnitPrice() {
@@ -116,8 +119,10 @@ public class BasketItem {
         this.name = name;
     }
 
+    @Deprecated
+    @DynamoDBIgnore
     public void setCategory(ProductCategory category) {
-        this.category = category;
+        this.category = category == null ? null : category.name();
     }
 
     public void setQty(long qty) {
@@ -150,11 +155,6 @@ public class BasketItem {
 
     public void setConsolidated(boolean consolidated) {
         this.consolidated = consolidated;
-    }
-
-    @DynamoDBIgnore
-    public boolean hasCategory(ProductCategory category) {
-        return this.category == category;
     }
 
     @DynamoDBIgnore

--- a/src/main/java/pl/commercelink/baskets/OfferItem.java
+++ b/src/main/java/pl/commercelink/baskets/OfferItem.java
@@ -1,7 +1,5 @@
 package pl.commercelink.baskets;
 
-import pl.commercelink.taxonomy.Categorized;
-
 import pl.commercelink.inventory.MatchedInventory;
 import java.util.LinkedList;
 import java.util.List;
@@ -63,7 +61,7 @@ public class OfferItem {
     public int getSequenceNumber() { return sequenceNumber; }
 
     public String getCostRangeDistribution() {
-        if (basketItem.hasCategoryKey(Categorized.SERVICES)) {
+        if (basketItem.isService()) {
             return "";
         }
 
@@ -71,7 +69,7 @@ public class OfferItem {
     }
 
     public String getQtyDistribution() {
-        if (basketItem.hasCategoryKey(Categorized.SERVICES)) {
+        if (basketItem.isService()) {
             return "";
         }
 
@@ -79,7 +77,7 @@ public class OfferItem {
     }
 
     public String getSuppliersDistribution() {
-        if (basketItem.hasCategoryKey(Categorized.SERVICES)) {
+        if (basketItem.isService()) {
             return "";
         }
 

--- a/src/main/java/pl/commercelink/baskets/OfferItem.java
+++ b/src/main/java/pl/commercelink/baskets/OfferItem.java
@@ -1,8 +1,8 @@
 package pl.commercelink.baskets;
 
-import pl.commercelink.inventory.MatchedInventory;
-import pl.commercelink.taxonomy.ProductCategory;
+import pl.commercelink.taxonomy.Categorized;
 
+import pl.commercelink.inventory.MatchedInventory;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -63,7 +63,7 @@ public class OfferItem {
     public int getSequenceNumber() { return sequenceNumber; }
 
     public String getCostRangeDistribution() {
-        if (basketItem.getCategory() == ProductCategory.Services) {
+        if (basketItem.hasCategoryKey(Categorized.SERVICES)) {
             return "";
         }
 
@@ -71,7 +71,7 @@ public class OfferItem {
     }
 
     public String getQtyDistribution() {
-        if (basketItem.getCategory() == ProductCategory.Services) {
+        if (basketItem.hasCategoryKey(Categorized.SERVICES)) {
             return "";
         }
 
@@ -79,7 +79,7 @@ public class OfferItem {
     }
 
     public String getSuppliersDistribution() {
-        if (basketItem.getCategory() == ProductCategory.Services) {
+        if (basketItem.hasCategoryKey(Categorized.SERVICES)) {
             return "";
         }
 

--- a/src/main/java/pl/commercelink/baskets/OfferItemReloader.java
+++ b/src/main/java/pl/commercelink/baskets/OfferItemReloader.java
@@ -164,10 +164,10 @@ public class OfferItemReloader {
     }
 
     private int getCategoryOrdinal(BasketItem basketItem) {
-        if (basketItem == null || basketItem.getCategory() == null) {
+        if (basketItem == null || basketItem.getCategoryKey() == null) {
             return Integer.MAX_VALUE;
         }
-        return basketItem.getCategory().ordinal();
+        return basketItem.getSequenceNumber();
     }
 
 }

--- a/src/main/java/pl/commercelink/invoicing/InvoicePositionName.java
+++ b/src/main/java/pl/commercelink/invoicing/InvoicePositionName.java
@@ -1,9 +1,9 @@
 package pl.commercelink.invoicing;
 
+import pl.commercelink.taxonomy.Categorized;
+
 import pl.commercelink.baskets.BasketItem;
 import pl.commercelink.orders.OrderItem;
-import pl.commercelink.taxonomy.ProductCategory;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,7 +19,7 @@ public class InvoicePositionName {
     public static String fromOrderItems(String prefix, List<OrderItem> orderItems) {
         return prefix + " " +
                 orderItems.stream()
-                        .filter(i -> i.getCategory() != ProductCategory.Services)
+                        .filter(i -> !i.hasCategoryKey(Categorized.SERVICES))
                         .map(i -> formatName(i.getName(), i.getQty()))
                         .collect(Collectors.joining(", "))
                         .trim();

--- a/src/main/java/pl/commercelink/invoicing/InvoicePositionName.java
+++ b/src/main/java/pl/commercelink/invoicing/InvoicePositionName.java
@@ -1,7 +1,5 @@
 package pl.commercelink.invoicing;
 
-import pl.commercelink.taxonomy.Categorized;
-
 import pl.commercelink.baskets.BasketItem;
 import pl.commercelink.orders.OrderItem;
 import java.util.List;
@@ -19,7 +17,7 @@ public class InvoicePositionName {
     public static String fromOrderItems(String prefix, List<OrderItem> orderItems) {
         return prefix + " " +
                 orderItems.stream()
-                        .filter(i -> !i.hasCategoryKey(Categorized.SERVICES))
+                        .filter(i -> i.isProduct())
                         .map(i -> formatName(i.getName(), i.getQty()))
                         .collect(Collectors.joining(", "))
                         .trim();

--- a/src/main/java/pl/commercelink/orders/Item.java
+++ b/src/main/java/pl/commercelink/orders/Item.java
@@ -176,7 +176,7 @@ public abstract class Item implements Delivered, Categorized {
 
     @DynamoDBIgnore
     public boolean isAllocated() {
-        if (hasGroupKey(SERVICES) && this.status == FulfilmentStatus.Delivered) {
+        if (isServiceGroup() && this.status == FulfilmentStatus.Delivered) {
             return true;
         }
         return hasAllocationDetails() && hasOneOfTheStatuses(FulfilmentStatus.Ordered, FulfilmentStatus.Delivered);
@@ -184,7 +184,7 @@ public abstract class Item implements Delivered, Categorized {
 
     @DynamoDBIgnore
     public boolean isOrdered() {
-        if (hasGroupKey(SERVICES) && this.status == FulfilmentStatus.Delivered) {
+        if (isServiceGroup() && this.status == FulfilmentStatus.Delivered) {
             return true;
         }
 

--- a/src/main/java/pl/commercelink/orders/Item.java
+++ b/src/main/java/pl/commercelink/orders/Item.java
@@ -6,8 +6,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 import pl.commercelink.inventory.deliveries.Delivered;
 import pl.commercelink.orders.fulfilment.FulfilmentSource;
 import pl.commercelink.invoicing.api.Price;
+import pl.commercelink.taxonomy.Categorized;
 import pl.commercelink.taxonomy.ProductCategory;
-import pl.commercelink.taxonomy.ProductGroup;
 import pl.commercelink.starter.dynamodb.DynamoDbLocalDateConverter;
 import pl.commercelink.starter.util.ConversionUtil;
 import pl.commercelink.warehouse.api.GoodsReceiptItem;
@@ -24,12 +24,10 @@ import static pl.commercelink.taxonomy.UnifiedProductIdentifiers.*;
 import static pl.commercelink.invoicing.api.Price.DEFAULT_VAT_RATE;
 
 @DynamoDBDocument
-public abstract class Item implements Delivered {
+public abstract class Item implements Delivered, Categorized {
 
     // general information
-    @DynamoDBAttribute(attributeName = "category")
-    @DynamoDBTypeConvertedEnum
-    private ProductCategory category = ProductCategory.Other;
+    private String category = "Other";
     @DynamoDBAttribute(attributeName = "name")
     private String name;
     @DynamoDBAttribute(attributeName = "qty")
@@ -63,7 +61,7 @@ public abstract class Item implements Delivered {
     }
 
     public Item(ProductCategory category, String name, int qty, String comment) {
-        this.category = category;
+        this.category = category == null ? null : category.name();
         this.name = name;
         this.qty = qty;
         this.comment = comment;
@@ -178,7 +176,7 @@ public abstract class Item implements Delivered {
 
     @DynamoDBIgnore
     public boolean isAllocated() {
-        if (hasGroup(ProductGroup.Services) && this.status == FulfilmentStatus.Delivered) {
+        if (hasGroupKey(SERVICES) && this.status == FulfilmentStatus.Delivered) {
             return true;
         }
         return hasAllocationDetails() && hasOneOfTheStatuses(FulfilmentStatus.Ordered, FulfilmentStatus.Delivered);
@@ -186,7 +184,7 @@ public abstract class Item implements Delivered {
 
     @DynamoDBIgnore
     public boolean isOrdered() {
-        if (hasGroup(ProductGroup.Services) && this.status == FulfilmentStatus.Delivered) {
+        if (hasGroupKey(SERVICES) && this.status == FulfilmentStatus.Delivered) {
             return true;
         }
 
@@ -210,16 +208,6 @@ public abstract class Item implements Delivered {
         return this.deliveryId.equalsIgnoreCase(removalItem.getDeliveryId())
                 && areEansEq(this.ean, removalItem.getEan())
                 && areMfnsEq(this.manufacturerCode, removalItem.getMfn());
-    }
-
-    @DynamoDBIgnore
-    public boolean hasGroup(ProductGroup group) {
-        return category.getProductGroup() == group;
-    }
-
-    @DynamoDBIgnore
-    public boolean hasCategory(ProductCategory category) {
-        return this.category == category;
     }
 
     @DynamoDBIgnore
@@ -259,11 +247,18 @@ public abstract class Item implements Delivered {
         return cost * qty;
     }
 
-    public ProductCategory getCategory() {
+    @Deprecated
+    @DynamoDBIgnore
+    public void setCategory(ProductCategory category) {
+        this.category = category == null ? null : category.name();
+    }
+
+    @DynamoDBAttribute(attributeName = "category")
+    public String getCategoryKey() {
         return category;
     }
 
-    public void setCategory(ProductCategory category) {
+    public void setCategoryKey(String category) {
         this.category = category;
     }
 

--- a/src/main/java/pl/commercelink/orders/Order.java
+++ b/src/main/java/pl/commercelink/orders/Order.java
@@ -1,7 +1,5 @@
 package pl.commercelink.orders;
 
-import pl.commercelink.taxonomy.Categorized;
-
 import com.amazonaws.services.dynamodbv2.datamodeling.*;
 import org.springframework.format.annotation.DateTimeFormat;
 import pl.commercelink.baskets.Basket;
@@ -281,7 +279,7 @@ public class Order {
 
     @DynamoDBIgnore
     public void increaseRealizationDays(OrderItem orderItem, int estimatedDeliveryDays) {
-        if (orderItem.hasCategoryKey(Categorized.SERVICES)) {
+        if (orderItem.isService()) {
             this.orderRealizationDays = Math.max(orderRealizationDays, estimatedDeliveryDays);
         }
     }
@@ -300,14 +298,14 @@ public class Order {
             return false;
         }
         return orderItems.stream()
-                .filter(i -> !i.hasCategoryKey(Categorized.SERVICES))
+                .filter(i -> i.isProduct())
                 .allMatch(OrderItem::isReturned);
     }
 
     @DynamoDBIgnore
     public void cancel(List<OrderItem> orderItems) {
         orderItems.stream()
-                .filter(i -> i.hasCategoryKey(Categorized.SERVICES))
+                .filter(i -> i.isService())
                 .forEach(OrderItem::markAsReturned);
 
         this.totalPrice = orderItems.stream()

--- a/src/main/java/pl/commercelink/orders/Order.java
+++ b/src/main/java/pl/commercelink/orders/Order.java
@@ -1,5 +1,7 @@
 package pl.commercelink.orders;
 
+import pl.commercelink.taxonomy.Categorized;
+
 import com.amazonaws.services.dynamodbv2.datamodeling.*;
 import org.springframework.format.annotation.DateTimeFormat;
 import pl.commercelink.baskets.Basket;
@@ -11,8 +13,6 @@ import pl.commercelink.starter.dynamodb.DynamoDbLocalDateConverter;
 import pl.commercelink.starter.dynamodb.DynamoDbLocalDateTimeConverter;
 import pl.commercelink.starter.util.ConversionUtil;
 import pl.commercelink.stores.Store;
-import pl.commercelink.taxonomy.ProductCategory;
-
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -281,7 +281,7 @@ public class Order {
 
     @DynamoDBIgnore
     public void increaseRealizationDays(OrderItem orderItem, int estimatedDeliveryDays) {
-        if (orderItem.hasCategory(ProductCategory.Services)) {
+        if (orderItem.hasCategoryKey(Categorized.SERVICES)) {
             this.orderRealizationDays = Math.max(orderRealizationDays, estimatedDeliveryDays);
         }
     }
@@ -300,14 +300,14 @@ public class Order {
             return false;
         }
         return orderItems.stream()
-                .filter(i -> !i.hasCategory(ProductCategory.Services))
+                .filter(i -> !i.hasCategoryKey(Categorized.SERVICES))
                 .allMatch(OrderItem::isReturned);
     }
 
     @DynamoDBIgnore
     public void cancel(List<OrderItem> orderItems) {
         orderItems.stream()
-                .filter(i -> i.hasCategory(ProductCategory.Services))
+                .filter(i -> i.hasCategoryKey(Categorized.SERVICES))
                 .forEach(OrderItem::markAsReturned);
 
         this.totalPrice = orderItems.stream()

--- a/src/main/java/pl/commercelink/orders/OrderFinancials.java
+++ b/src/main/java/pl/commercelink/orders/OrderFinancials.java
@@ -1,7 +1,5 @@
 package pl.commercelink.orders;
 
-import pl.commercelink.taxonomy.Categorized;
-
 import pl.commercelink.invoicing.api.Price;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -24,10 +22,10 @@ public class OrderFinancials {
     private double unpaidAmount;
 
     public OrderFinancials(Order order, List<OrderItem> orderItems) {
-        this.totalItemsPrice = orderItems.stream().filter(i -> !i.hasGroupKey(Categorized.SERVICES)).mapToDouble(OrderItem::getTotalPrice).sum();
-        this.totalItemsCost = orderItems.stream().filter(i -> !i.hasGroupKey(Categorized.SERVICES)).mapToDouble(OrderItem::getTotalCost).sum();
-        this.totalServicesPrice = orderItems.stream().filter(i -> i.hasGroupKey(Categorized.SERVICES)).mapToDouble(OrderItem::getTotalPrice).sum();
-        this.totalServicesCost = orderItems.stream().filter(i -> i.hasGroupKey(Categorized.SERVICES)).mapToDouble(OrderItem::getTotalCost).sum();
+        this.totalItemsPrice = orderItems.stream().filter(i -> !i.isServiceGroup()).mapToDouble(OrderItem::getTotalPrice).sum();
+        this.totalItemsCost = orderItems.stream().filter(i -> !i.isServiceGroup()).mapToDouble(OrderItem::getTotalCost).sum();
+        this.totalServicesPrice = orderItems.stream().filter(i -> i.isServiceGroup()).mapToDouble(OrderItem::getTotalPrice).sum();
+        this.totalServicesCost = orderItems.stream().filter(i -> i.isServiceGroup()).mapToDouble(OrderItem::getTotalCost).sum();
         this.totalProcessingFeesCost = order.getPayments().stream().mapToDouble(Payment::getFee).sum();
 
         this.totalPrice = totalItemsPrice + totalServicesPrice;

--- a/src/main/java/pl/commercelink/orders/OrderFinancials.java
+++ b/src/main/java/pl/commercelink/orders/OrderFinancials.java
@@ -1,8 +1,8 @@
 package pl.commercelink.orders;
 
-import pl.commercelink.invoicing.api.Price;
-import pl.commercelink.taxonomy.ProductGroup;
+import pl.commercelink.taxonomy.Categorized;
 
+import pl.commercelink.invoicing.api.Price;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
@@ -24,10 +24,10 @@ public class OrderFinancials {
     private double unpaidAmount;
 
     public OrderFinancials(Order order, List<OrderItem> orderItems) {
-        this.totalItemsPrice = orderItems.stream().filter(i -> !i.hasGroup(ProductGroup.Services)).mapToDouble(OrderItem::getTotalPrice).sum();
-        this.totalItemsCost = orderItems.stream().filter(i -> !i.hasGroup(ProductGroup.Services)).mapToDouble(OrderItem::getTotalCost).sum();
-        this.totalServicesPrice = orderItems.stream().filter(i -> i.hasGroup(ProductGroup.Services)).mapToDouble(OrderItem::getTotalPrice).sum();
-        this.totalServicesCost = orderItems.stream().filter(i -> i.hasGroup(ProductGroup.Services)).mapToDouble(OrderItem::getTotalCost).sum();
+        this.totalItemsPrice = orderItems.stream().filter(i -> !i.hasGroupKey(Categorized.SERVICES)).mapToDouble(OrderItem::getTotalPrice).sum();
+        this.totalItemsCost = orderItems.stream().filter(i -> !i.hasGroupKey(Categorized.SERVICES)).mapToDouble(OrderItem::getTotalCost).sum();
+        this.totalServicesPrice = orderItems.stream().filter(i -> i.hasGroupKey(Categorized.SERVICES)).mapToDouble(OrderItem::getTotalPrice).sum();
+        this.totalServicesCost = orderItems.stream().filter(i -> i.hasGroupKey(Categorized.SERVICES)).mapToDouble(OrderItem::getTotalCost).sum();
         this.totalProcessingFeesCost = order.getPayments().stream().mapToDouble(Payment::getFee).sum();
 
         this.totalPrice = totalItemsPrice + totalServicesPrice;

--- a/src/main/java/pl/commercelink/orders/OrderItem.java
+++ b/src/main/java/pl/commercelink/orders/OrderItem.java
@@ -67,7 +67,7 @@ public class OrderItem extends Item {
     }
 
     public void markAsWarehouseFulfilled() {
-        if (hasCategory(ProductCategory.Services)) {
+        if (hasCategoryKey(SERVICES)) {
             setDeliveryId(GENERIC_WAREHOUSE_ORDER_NO);
             markAsReceived();
         }
@@ -228,13 +228,8 @@ public class OrderItem extends Item {
     }
 
     @DynamoDBIgnore
-    public int getSequenceNumber() {
-        return getCategory().ordinal();
-    }
-
-    @DynamoDBIgnore
     public boolean canBeFulfilledInternally() {
-        return getCategory() == ProductCategory.Services && isWarehouseFulfilled();
+        return hasCategoryKey(SERVICES) && isWarehouseFulfilled();
     }
 
     @DynamoDBIgnore

--- a/src/main/java/pl/commercelink/orders/OrderItem.java
+++ b/src/main/java/pl/commercelink/orders/OrderItem.java
@@ -67,7 +67,7 @@ public class OrderItem extends Item {
     }
 
     public void markAsWarehouseFulfilled() {
-        if (hasCategoryKey(SERVICES)) {
+        if (isService()) {
             setDeliveryId(GENERIC_WAREHOUSE_ORDER_NO);
             markAsReceived();
         }
@@ -229,7 +229,7 @@ public class OrderItem extends Item {
 
     @DynamoDBIgnore
     public boolean canBeFulfilledInternally() {
-        return hasCategoryKey(SERVICES) && isWarehouseFulfilled();
+        return isService() && isWarehouseFulfilled();
     }
 
     @DynamoDBIgnore

--- a/src/main/java/pl/commercelink/orders/OrdersManager.java
+++ b/src/main/java/pl/commercelink/orders/OrdersManager.java
@@ -1,7 +1,5 @@
 package pl.commercelink.orders;
 
-import pl.commercelink.taxonomy.Categorized;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -73,7 +71,7 @@ public class OrdersManager {
                 availabilityAndPrice.getManufacturerCode(),
                 store.isPositionConsolidationEnabled()
         );
-        if (orderItem.hasCategoryKey(Categorized.SERVICES)) {
+        if (orderItem.isService()) {
             orderItem.markAsWarehouseFulfilled();
         }
 
@@ -92,7 +90,7 @@ public class OrdersManager {
                 .collect(Collectors.toList());
 
         for (OrderItem selectedOrderItem : selectedOrderItems) {
-            if (selectedOrderItem.isNew() || selectedOrderItem.hasCategoryKey(Categorized.SERVICES)) {
+            if (selectedOrderItem.isNew() || selectedOrderItem.isService()) {
                 orderItems.remove(selectedOrderItem);
                 orderItemsRepository.delete(selectedOrderItem);
 

--- a/src/main/java/pl/commercelink/orders/OrdersManager.java
+++ b/src/main/java/pl/commercelink/orders/OrdersManager.java
@@ -1,5 +1,7 @@
 package pl.commercelink.orders;
 
+import pl.commercelink.taxonomy.Categorized;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -71,7 +73,7 @@ public class OrdersManager {
                 availabilityAndPrice.getManufacturerCode(),
                 store.isPositionConsolidationEnabled()
         );
-        if (orderItem.hasCategory(ProductCategory.Services)) {
+        if (orderItem.hasCategoryKey(Categorized.SERVICES)) {
             orderItem.markAsWarehouseFulfilled();
         }
 
@@ -90,7 +92,7 @@ public class OrdersManager {
                 .collect(Collectors.toList());
 
         for (OrderItem selectedOrderItem : selectedOrderItems) {
-            if (selectedOrderItem.isNew() || selectedOrderItem.getCategory() == ProductCategory.Services) {
+            if (selectedOrderItem.isNew() || selectedOrderItem.hasCategoryKey(Categorized.SERVICES)) {
                 orderItems.remove(selectedOrderItem);
                 orderItemsRepository.delete(selectedOrderItem);
 

--- a/src/main/java/pl/commercelink/orders/fulfilment/FulfilmentGroup.java
+++ b/src/main/java/pl/commercelink/orders/fulfilment/FulfilmentGroup.java
@@ -69,7 +69,7 @@ public class FulfilmentGroup {
     }
 
     public int getFirstSortNumber() {
-        return source.getCategory().ordinal();
+        return source.getSequenceNumber();
     }
 
     public int getSecondSortNumber() {

--- a/src/main/java/pl/commercelink/orders/fulfilment/FulfilmentGroupsGenerator.java
+++ b/src/main/java/pl/commercelink/orders/fulfilment/FulfilmentGroupsGenerator.java
@@ -1,7 +1,5 @@
 package pl.commercelink.orders.fulfilment;
 
-import pl.commercelink.taxonomy.Categorized;
-
 import pl.commercelink.inventory.supplier.api.InventoryItem;
 import pl.commercelink.inventory.InventoryView;
 import pl.commercelink.orders.OrderItem;
@@ -60,8 +58,8 @@ public class FulfilmentGroupsGenerator {
                 .flatMap(List::stream)
                 .filter(FulfilmentItem::hasProvider)
                 .filter(c -> acceptedSuppliers.isEmpty() || acceptedSuppliers.contains(c.getSource().getProvider()))
-                .filter(c -> c.getSource().hasCategoryKey(Categorized.SERVICES) || isNotBlank(c.getSource().getEan()))
-                .filter(c -> c.getSource().hasCategoryKey(Categorized.SERVICES) || isNotBlank(c.getSource().getMfn()))
+                .filter(c -> c.getSource().isService() || isNotBlank(c.getSource().getEan()))
+                .filter(c -> c.getSource().isService() || isNotBlank(c.getSource().getMfn()))
                 .filter(c -> !enforceFulfilmentUnderCost || c.getSource().getPriceGross() > 0)
                 .filter(c -> !enforceFulfilmentUnderCost || c.getAllocation().getOrderItemPrice() >= c.getSource().getPriceGross())
                 .filter(c -> !enforceCompleteFulfilment || c.getSource().getQty() >= c.getAllocation().getOrderItemQty())
@@ -72,7 +70,7 @@ public class FulfilmentGroupsGenerator {
     }
 
     private List<FulfilmentItem> createFulfilments(OrderItem orderItem) {
-        if (orderItem.hasCategoryKey(Categorized.SERVICES)) {
+        if (orderItem.isService()) {
             return Collections.singletonList(FulfilmentItem.internal(orderItem));
         }
 

--- a/src/main/java/pl/commercelink/orders/fulfilment/FulfilmentGroupsGenerator.java
+++ b/src/main/java/pl/commercelink/orders/fulfilment/FulfilmentGroupsGenerator.java
@@ -1,10 +1,10 @@
 package pl.commercelink.orders.fulfilment;
 
+import pl.commercelink.taxonomy.Categorized;
+
 import pl.commercelink.inventory.supplier.api.InventoryItem;
 import pl.commercelink.inventory.InventoryView;
 import pl.commercelink.orders.OrderItem;
-import pl.commercelink.taxonomy.ProductCategory;
-
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -60,8 +60,8 @@ public class FulfilmentGroupsGenerator {
                 .flatMap(List::stream)
                 .filter(FulfilmentItem::hasProvider)
                 .filter(c -> acceptedSuppliers.isEmpty() || acceptedSuppliers.contains(c.getSource().getProvider()))
-                .filter(c -> ProductCategory.Services == c.getSource().getCategory() || isNotBlank(c.getSource().getEan()))
-                .filter(c -> ProductCategory.Services == c.getSource().getCategory() || isNotBlank(c.getSource().getMfn()))
+                .filter(c -> c.getSource().hasCategoryKey(Categorized.SERVICES) || isNotBlank(c.getSource().getEan()))
+                .filter(c -> c.getSource().hasCategoryKey(Categorized.SERVICES) || isNotBlank(c.getSource().getMfn()))
                 .filter(c -> !enforceFulfilmentUnderCost || c.getSource().getPriceGross() > 0)
                 .filter(c -> !enforceFulfilmentUnderCost || c.getAllocation().getOrderItemPrice() >= c.getSource().getPriceGross())
                 .filter(c -> !enforceCompleteFulfilment || c.getSource().getQty() >= c.getAllocation().getOrderItemQty())
@@ -72,7 +72,7 @@ public class FulfilmentGroupsGenerator {
     }
 
     private List<FulfilmentItem> createFulfilments(OrderItem orderItem) {
-        if (orderItem.hasCategory(ProductCategory.Services)) {
+        if (orderItem.hasCategoryKey(Categorized.SERVICES)) {
             return Collections.singletonList(FulfilmentItem.internal(orderItem));
         }
 

--- a/src/main/java/pl/commercelink/orders/fulfilment/FulfilmentItem.java
+++ b/src/main/java/pl/commercelink/orders/fulfilment/FulfilmentItem.java
@@ -89,7 +89,7 @@ public class FulfilmentItem {
     }
 
     public int getFirstSortNumber() {
-        return source.getCategory().ordinal();
+        return source.getSequenceNumber();
     }
 
     public int getSecondSortNumber() {

--- a/src/main/java/pl/commercelink/orders/fulfilment/FulfilmentSource.java
+++ b/src/main/java/pl/commercelink/orders/fulfilment/FulfilmentSource.java
@@ -3,11 +3,12 @@ package pl.commercelink.orders.fulfilment;
 import pl.commercelink.inventory.supplier.api.InventoryItem;
 import pl.commercelink.invoicing.api.Price;
 import pl.commercelink.orders.OrderItem;
+import pl.commercelink.taxonomy.Categorized;
 import pl.commercelink.taxonomy.ProductCategory;
 
 import java.util.Objects;
 
-public class FulfilmentSource {
+public class FulfilmentSource implements Categorized {
 
     private String name;
     private ProductCategory category;
@@ -85,6 +86,10 @@ public class FulfilmentSource {
 
     public void setCategory(ProductCategory category) {
         this.category = category;
+    }
+
+    public String getCategoryKey() {
+        return category == null ? null : category.name();
     }
 
     public int getQty() {

--- a/src/main/java/pl/commercelink/orders/fulfilment/OrderFulfilment.java
+++ b/src/main/java/pl/commercelink/orders/fulfilment/OrderFulfilment.java
@@ -1,7 +1,5 @@
 package pl.commercelink.orders.fulfilment;
 
-import pl.commercelink.taxonomy.Categorized;
-
 import pl.commercelink.orders.*;
 import pl.commercelink.warehouse.WarehouseFulfilmentService;
 
@@ -59,13 +57,13 @@ abstract class OrderFulfilment {
         List<OrderItem> acceptedProducts = orderItems.stream()
                 .filter(i -> !i.isInAllocation())
                 .filter(i -> !i.isAllocated())
-                .filter(i -> !i.hasCategoryKey(Categorized.SERVICES))
+                .filter(i -> i.isProduct())
                 .collect(Collectors.toList());
 
         List<OrderItem> acceptedServices = orderItems.stream()
                 .filter(i -> !i.isInAllocation())
                 .filter(i -> !i.isAllocated())
-                .filter(i -> i.hasCategoryKey(Categorized.SERVICES))
+                .filter(i -> i.isService())
                 .peek(OrderItem::markAsReceived)
                 .collect(Collectors.toList());
 

--- a/src/main/java/pl/commercelink/orders/fulfilment/OrderFulfilment.java
+++ b/src/main/java/pl/commercelink/orders/fulfilment/OrderFulfilment.java
@@ -1,7 +1,8 @@
 package pl.commercelink.orders.fulfilment;
 
+import pl.commercelink.taxonomy.Categorized;
+
 import pl.commercelink.orders.*;
-import pl.commercelink.taxonomy.ProductCategory;
 import pl.commercelink.warehouse.WarehouseFulfilmentService;
 
 import java.util.LinkedList;
@@ -58,13 +59,13 @@ abstract class OrderFulfilment {
         List<OrderItem> acceptedProducts = orderItems.stream()
                 .filter(i -> !i.isInAllocation())
                 .filter(i -> !i.isAllocated())
-                .filter(i -> !i.hasCategory(ProductCategory.Services))
+                .filter(i -> !i.hasCategoryKey(Categorized.SERVICES))
                 .collect(Collectors.toList());
 
         List<OrderItem> acceptedServices = orderItems.stream()
                 .filter(i -> !i.isInAllocation())
                 .filter(i -> !i.isAllocated())
-                .filter(i -> i.hasCategory(ProductCategory.Services))
+                .filter(i -> i.hasCategoryKey(Categorized.SERVICES))
                 .peek(OrderItem::markAsReceived)
                 .collect(Collectors.toList());
 

--- a/src/main/java/pl/commercelink/orders/notifications/OrderConfirmationEmailNotification.java
+++ b/src/main/java/pl/commercelink/orders/notifications/OrderConfirmationEmailNotification.java
@@ -1,5 +1,7 @@
 package pl.commercelink.orders.notifications;
 
+import pl.commercelink.taxonomy.Categorized;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import pl.commercelink.documents.DocumentType;
@@ -7,8 +9,6 @@ import pl.commercelink.starter.email.EmailNotification;
 import pl.commercelink.orders.OrderItem;
 import pl.commercelink.orders.ShippingDetails;
 import pl.commercelink.starter.localization.EnumLocalizer;
-import pl.commercelink.taxonomy.ProductCategory;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -45,11 +45,11 @@ class OrderConfirmationEmailNotification extends EmailNotification {
         this.personalCollection = personalCollection;
 
         this.products = orderItems.stream()
-                .filter(o -> !o.hasCategory(ProductCategory.Services))
+                .filter(o -> !o.hasCategoryKey(Categorized.SERVICES))
                 .map(o -> LocalizedOrderItem.fromOrderItem(o, enumLocalizer))
                 .collect(Collectors.toList());
         this.services = orderItems.stream()
-                .filter(o -> o.hasCategory(ProductCategory.Services))
+                .filter(o -> o.hasCategoryKey(Categorized.SERVICES))
                 .map(o -> LocalizedOrderItem.fromOrderItem(o, enumLocalizer))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/pl/commercelink/orders/notifications/OrderConfirmationEmailNotification.java
+++ b/src/main/java/pl/commercelink/orders/notifications/OrderConfirmationEmailNotification.java
@@ -1,7 +1,5 @@
 package pl.commercelink.orders.notifications;
 
-import pl.commercelink.taxonomy.Categorized;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import pl.commercelink.documents.DocumentType;
@@ -45,11 +43,11 @@ class OrderConfirmationEmailNotification extends EmailNotification {
         this.personalCollection = personalCollection;
 
         this.products = orderItems.stream()
-                .filter(o -> !o.hasCategoryKey(Categorized.SERVICES))
+                .filter(o -> o.isProduct())
                 .map(o -> LocalizedOrderItem.fromOrderItem(o, enumLocalizer))
                 .collect(Collectors.toList());
         this.services = orderItems.stream()
-                .filter(o -> o.hasCategoryKey(Categorized.SERVICES))
+                .filter(o -> o.isService())
                 .map(o -> LocalizedOrderItem.fromOrderItem(o, enumLocalizer))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/pl/commercelink/taxonomy/Categorized.java
+++ b/src/main/java/pl/commercelink/taxonomy/Categorized.java
@@ -24,6 +24,21 @@ public interface Categorized {
     }
 
     @DynamoDBIgnore
+    default boolean isService() {
+        return hasCategoryKey(SERVICES);
+    }
+
+    @DynamoDBIgnore
+    default boolean isProduct() {
+        return !isService();
+    }
+
+    @DynamoDBIgnore
+    default boolean isServiceGroup() {
+        return hasGroupKey(SERVICES);
+    }
+
+    @DynamoDBIgnore
     default int getSequenceNumber() {
         return getCategory().ordinal();
     }

--- a/src/main/java/pl/commercelink/taxonomy/Categorized.java
+++ b/src/main/java/pl/commercelink/taxonomy/Categorized.java
@@ -1,0 +1,36 @@
+package pl.commercelink.taxonomy;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
+
+public interface Categorized {
+
+    String SERVICES = "Services";
+
+    String getCategoryKey();
+
+    @DynamoDBIgnore
+    default ProductCategory getCategory() {
+        return getCategoryKey() == null ? null : ProductCategory.valueOf(getCategoryKey());
+    }
+
+    @DynamoDBIgnore
+    default boolean hasCategoryKey(String key) {
+        return getCategoryKey() != null && getCategoryKey().equals(key);
+    }
+
+    @DynamoDBIgnore
+    default boolean hasGroupKey(String groupKey) {
+        return getCategory() != null && getCategory().getProductGroup().name().equals(groupKey);
+    }
+
+    @DynamoDBIgnore
+    default int getSequenceNumber() {
+        return getCategory().ordinal();
+    }
+
+    @Deprecated
+    @DynamoDBIgnore
+    default boolean hasCategory(ProductCategory category) {
+        return getCategory() == category;
+    }
+}

--- a/src/main/java/pl/commercelink/warehouse/GoodsOutService.java
+++ b/src/main/java/pl/commercelink/warehouse/GoodsOutService.java
@@ -1,7 +1,5 @@
 package pl.commercelink.warehouse;
 
-import pl.commercelink.taxonomy.Categorized;
-
 import org.springframework.stereotype.Service;
 import pl.commercelink.documents.Document;
 import pl.commercelink.documents.DocumentReason;
@@ -80,7 +78,7 @@ class GoodsOutService {
 
         List<OrderItem> orderItems = orderItemsRepository.findByOrderId(order.getOrderId())
                 .stream()
-                .filter(i -> !i.hasCategoryKey(Categorized.SERVICES))
+                .filter(i -> i.isProduct())
                 .toList();
 
         List<GoodsOutItem> items = orderItems.stream()

--- a/src/main/java/pl/commercelink/warehouse/GoodsOutService.java
+++ b/src/main/java/pl/commercelink/warehouse/GoodsOutService.java
@@ -1,5 +1,7 @@
 package pl.commercelink.warehouse;
 
+import pl.commercelink.taxonomy.Categorized;
+
 import org.springframework.stereotype.Service;
 import pl.commercelink.documents.Document;
 import pl.commercelink.documents.DocumentReason;
@@ -11,7 +13,6 @@ import pl.commercelink.orders.Order;
 import pl.commercelink.orders.OrderItem;
 import pl.commercelink.orders.OrderItemsRepository;
 import pl.commercelink.orders.OrdersRepository;
-import pl.commercelink.taxonomy.ProductCategory;
 import pl.commercelink.stores.Store;
 import pl.commercelink.stores.StoresRepository;
 import pl.commercelink.stores.WarehouseConfiguration;
@@ -79,7 +80,7 @@ class GoodsOutService {
 
         List<OrderItem> orderItems = orderItemsRepository.findByOrderId(order.getOrderId())
                 .stream()
-                .filter(i -> !i.hasCategory(ProductCategory.Services))
+                .filter(i -> !i.hasCategoryKey(Categorized.SERVICES))
                 .toList();
 
         List<GoodsOutItem> items = orderItems.stream()

--- a/src/test/java/pl/commercelink/orders/CategoryKeyHelpersTest.java
+++ b/src/test/java/pl/commercelink/orders/CategoryKeyHelpersTest.java
@@ -90,6 +90,81 @@ class CategoryKeyHelpersTest {
         assertThat(item.hasCategoryKey("Services")).isFalse();
     }
 
+    @Test
+    void isServiceMatchesEnumCategoryCheck() {
+        // given
+        OrderItem service = orderItemWithCategory(ProductCategory.Services);
+        OrderItem laptop = orderItemWithCategory(ProductCategory.Laptops);
+
+        // when / then
+        assertThat(service.isService())
+                .isEqualTo(service.getCategory() == ProductCategory.Services)
+                .isTrue();
+        assertThat(laptop.isService())
+                .isEqualTo(laptop.getCategory() == ProductCategory.Services)
+                .isFalse();
+    }
+
+    @Test
+    void isProductIsExactInverseOfIsServiceCategory() {
+        // given
+        OrderItem service = orderItemWithCategory(ProductCategory.Services);
+        OrderItem laptop = orderItemWithCategory(ProductCategory.Laptops);
+
+        // when / then
+        assertThat(service.isProduct())
+                .isEqualTo(service.getCategory() != ProductCategory.Services)
+                .isFalse();
+        assertThat(laptop.isProduct())
+                .isEqualTo(laptop.getCategory() != ProductCategory.Services)
+                .isTrue();
+    }
+
+    @Test
+    void isServiceGroupMatchesEnumGroupCheck() {
+        // given
+        OrderItem service = orderItemWithCategory(ProductCategory.Services);
+        OrderItem laptop = orderItemWithCategory(ProductCategory.Laptops);
+
+        // when / then
+        assertThat(service.isServiceGroup())
+                .isEqualTo(service.getCategory().getProductGroup() == ProductGroup.Services)
+                .isTrue();
+        assertThat(laptop.isServiceGroup())
+                .isEqualTo(laptop.getCategory().getProductGroup() == ProductGroup.Services)
+                .isFalse();
+    }
+
+    @Test
+    void serviceCategoryAndServiceGroupStayDistinctPredicates() {
+        // given
+        OrderItem laptop = orderItemWithCategory(ProductCategory.Laptops);
+        OrderItem service = orderItemWithCategory(ProductCategory.Services);
+
+        // when / then
+        assertThat(laptop.isService()).isFalse();
+        assertThat(laptop.isServiceGroup()).isFalse();
+        assertThat(service.isService()).isTrue();
+        assertThat(service.isServiceGroup()).isTrue();
+    }
+
+    @Test
+    void basketItemServicePredicatesMatchEnumChecks() {
+        // given
+        BasketItem service = basketItemWithCategory(ProductCategory.Services);
+        BasketItem laptop = basketItemWithCategory(ProductCategory.Laptops);
+
+        // when / then
+        assertThat(service.isService())
+                .isEqualTo(service.getCategory() == ProductCategory.Services)
+                .isTrue();
+        assertThat(service.isProduct()).isFalse();
+        assertThat(laptop.isService()).isFalse();
+        assertThat(laptop.isProduct())
+                .isEqualTo(laptop.getCategory() != ProductCategory.Services)
+                .isTrue();
+    }
+
     private OrderItem orderItemWithCategory(ProductCategory category) {
         OrderItem item = new OrderItem();
         item.setCategoryKey(category.name());

--- a/src/test/java/pl/commercelink/orders/CategoryKeyHelpersTest.java
+++ b/src/test/java/pl/commercelink/orders/CategoryKeyHelpersTest.java
@@ -1,0 +1,104 @@
+package pl.commercelink.orders;
+
+import org.junit.jupiter.api.Test;
+import pl.commercelink.baskets.BasketItem;
+import pl.commercelink.taxonomy.ProductCategory;
+import pl.commercelink.taxonomy.ProductGroup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CategoryKeyHelpersTest {
+
+    @Test
+    void hasCategoryKeyMatchesEnumCategoryCheck() {
+        // given
+        OrderItem service = orderItemWithCategory(ProductCategory.Services);
+        OrderItem laptop = orderItemWithCategory(ProductCategory.Laptops);
+
+        // when / then
+        assertThat(service.hasCategoryKey("Services"))
+                .isEqualTo(service.getCategory() == ProductCategory.Services)
+                .isTrue();
+        assertThat(laptop.hasCategoryKey("Services"))
+                .isEqualTo(laptop.getCategory() == ProductCategory.Services)
+                .isFalse();
+    }
+
+    @Test
+    void hasGroupKeyMatchesEnumGroupCheck() {
+        // given
+        OrderItem service = orderItemWithCategory(ProductCategory.Services);
+        OrderItem laptop = orderItemWithCategory(ProductCategory.Laptops);
+
+        // when / then
+        assertThat(service.hasGroupKey("Services"))
+                .isEqualTo(service.getCategory().getProductGroup() == ProductGroup.Services)
+                .isTrue();
+        assertThat(laptop.hasGroupKey("Services"))
+                .isEqualTo(laptop.getCategory().getProductGroup() == ProductGroup.Services)
+                .isFalse();
+    }
+
+    @Test
+    void sequenceNumberMatchesEnumOrdinal() {
+        // given
+        OrderItem laptop = orderItemWithCategory(ProductCategory.Laptops);
+
+        // when
+        int sequence = laptop.getSequenceNumber();
+
+        // then
+        assertThat(sequence).isEqualTo(ProductCategory.Laptops.ordinal());
+    }
+
+    @Test
+    void categoryKeyAndGroupKeyAreNotConflated() {
+        // given
+        OrderItem laptop = orderItemWithCategory(ProductCategory.Laptops);
+        String groupKey = ProductCategory.Laptops.getProductGroup().name();
+
+        // when / then
+        assertThat(laptop.hasGroupKey(groupKey)).isTrue();
+        assertThat(laptop.hasCategoryKey(groupKey)).isFalse();
+        assertThat(laptop.hasCategoryKey("Laptops")).isTrue();
+        assertThat(laptop.hasGroupKey("Laptops")).isFalse();
+    }
+
+    @Test
+    void basketItemHelpersMatchEnumChecks() {
+        // given
+        BasketItem service = basketItemWithCategory(ProductCategory.Services);
+        BasketItem laptop = basketItemWithCategory(ProductCategory.Laptops);
+
+        // when / then
+        assertThat(service.hasCategoryKey("Services")).isTrue();
+        assertThat(service.isService()).isTrue();
+        assertThat(service.isProduct()).isFalse();
+        assertThat(laptop.isProduct()).isTrue();
+        assertThat(laptop.getSequenceNumber()).isEqualTo(ProductCategory.Laptops.ordinal());
+    }
+
+    @Test
+    void basketItemWithNullCategoryIsProductWithoutException() {
+        // given
+        BasketItem item = new BasketItem();
+
+        // when / then
+        assertThat(item.getCategoryKey()).isNull();
+        assertThat(item.isProduct()).isTrue();
+        assertThat(item.isService()).isFalse();
+        assertThat(item.hasCategoryKey("Services")).isFalse();
+    }
+
+    private OrderItem orderItemWithCategory(ProductCategory category) {
+        OrderItem item = new OrderItem();
+        item.setCategoryKey(category.name());
+        return item;
+    }
+
+    private BasketItem basketItemWithCategory(ProductCategory category) {
+        BasketItem item = new BasketItem();
+        item.setCategoryKey(category.name());
+        return item;
+    }
+}

--- a/src/test/java/pl/commercelink/orders/CategoryStringPersistenceTest.java
+++ b/src/test/java/pl/commercelink/orders/CategoryStringPersistenceTest.java
@@ -51,7 +51,7 @@ class CategoryStringPersistenceTest {
         // then
         assertThat(attributes.get("category").getS()).isEqualTo("Services");
         assertThat(attributes.get("category").getN()).isNull();
-        assertThat(attributes).doesNotContainKeys("sequenceNumber", "categoryKey");
+        assertThat(attributes).doesNotContainKeys("sequenceNumber", "categoryKey", "service", "product", "serviceGroup");
     }
 
     @Test
@@ -114,7 +114,7 @@ class CategoryStringPersistenceTest {
         // then
         assertThat(attributes.get("category").getS()).isEqualTo("Services");
         assertThat(attributes.get("category").getN()).isNull();
-        assertThat(attributes).doesNotContainKeys("sequenceNumber", "categoryKey");
+        assertThat(attributes).doesNotContainKeys("sequenceNumber", "categoryKey", "service", "product", "serviceGroup");
     }
 
     @Test
@@ -135,7 +135,7 @@ class CategoryStringPersistenceTest {
         // then
         assertThat(nested.get("category").getS()).isEqualTo("Laptop");
         assertThat(nested.get("category").getN()).isNull();
-        assertThat(nested).doesNotContainKeys("sequenceNumber", "categoryKey");
+        assertThat(nested).doesNotContainKeys("sequenceNumber", "categoryKey", "service", "product", "serviceGroup");
     }
 
     private DynamoDBMapperTableModel<OrderItem> orderItemModel() {

--- a/src/test/java/pl/commercelink/orders/CategoryStringPersistenceTest.java
+++ b/src/test/java/pl/commercelink/orders/CategoryStringPersistenceTest.java
@@ -1,0 +1,145 @@
+package pl.commercelink.orders;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperTableModel;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import org.junit.jupiter.api.Test;
+import pl.commercelink.baskets.Basket;
+import pl.commercelink.baskets.BasketItem;
+import pl.commercelink.taxonomy.ProductCategory;
+import pl.commercelink.warehouse.builtin.WarehouseItem;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class CategoryStringPersistenceTest {
+
+    @Test
+    void categoryPersistsAsRawStringAttribute() {
+        // given
+        OrderItem item = new OrderItem();
+        item.setOrderId("order-1");
+        item.setItemId("item-1");
+        item.setCategoryKey("Laptop");
+
+        // when
+        DynamoDBMapperTableModel<OrderItem> model = orderItemModel();
+        Map<String, AttributeValue> attributes = model.convert(item);
+        OrderItem restored = model.unconvert(attributes);
+
+        // then
+        assertThat(attributes.get("category").getS()).isEqualTo("Laptop");
+        assertThat(restored.getCategoryKey()).isEqualTo("Laptop");
+    }
+
+    @Test
+    void marshallingDoesNotLeakInterfaceDefaultAttributes() {
+        // given
+        OrderItem item = new OrderItem();
+        item.setOrderId("order-1");
+        item.setItemId("item-1");
+        item.setCategoryKey("Services");
+
+        // when
+        Map<String, AttributeValue> attributes = orderItemModel().convert(item);
+
+        // then
+        assertThat(attributes.get("category").getS()).isEqualTo("Services");
+        assertThat(attributes.get("category").getN()).isNull();
+        assertThat(attributes).doesNotContainKeys("sequenceNumber", "categoryKey");
+    }
+
+    @Test
+    void enumBridgeWritesByteIdenticalString() {
+        // given
+        OrderItem item = new OrderItem();
+        item.setOrderId("order-1");
+        item.setItemId("item-1");
+        item.setCategory(ProductCategory.Services);
+
+        // when
+        Map<String, AttributeValue> attributes = orderItemModel().convert(item);
+
+        // then
+        assertThat(attributes.get("category").getS()).isEqualTo("Services");
+    }
+
+    @Test
+    void bridgeExposesEnumAndRawKey() {
+        // given
+        OrderItem item = new OrderItem();
+        item.setCategoryKey("Services");
+
+        // when
+        ProductCategory category = item.getCategory();
+        String categoryKey = item.getCategoryKey();
+
+        // then
+        assertThat(category).isEqualTo(ProductCategory.Services);
+        assertThat(categoryKey).isEqualTo("Services");
+    }
+
+    @Test
+    void basketItemWithNullCategoryReturnsNullWithoutException() {
+        // given
+        BasketItem basketItem = new BasketItem();
+
+        // when
+        ProductCategory category = basketItem.getCategory();
+        String categoryKey = basketItem.getCategoryKey();
+
+        // then
+        assertThat(category).isNull();
+        assertThat(categoryKey).isNull();
+    }
+
+    @Test
+    void warehouseItemCategoryPersistsAsStringAttribute() {
+        // given
+        WarehouseItem item = new WarehouseItem();
+        item.setStoreId("store-1");
+        item.setItemId("item-1");
+        item.setCategoryKey("Services");
+
+        // when
+        DynamoDBMapper mapper = new DynamoDBMapper(mock(AmazonDynamoDB.class));
+        Map<String, AttributeValue> attributes =
+                mapper.getTableModel(WarehouseItem.class, DynamoDBMapperConfig.DEFAULT).convert(item);
+
+        // then
+        assertThat(attributes.get("category").getS()).isEqualTo("Services");
+        assertThat(attributes.get("category").getN()).isNull();
+        assertThat(attributes).doesNotContainKeys("sequenceNumber", "categoryKey");
+    }
+
+    @Test
+    void basketItemCategoryPersistsAsStringInNestedDocument() {
+        // given
+        BasketItem basketItem = new BasketItem();
+        basketItem.setCategoryKey("Laptop");
+        Basket basket = new Basket();
+        basket.setStoreId("store-1");
+        basket.setBasketItems(List.of(basketItem));
+
+        // when
+        DynamoDBMapper mapper = new DynamoDBMapper(mock(AmazonDynamoDB.class));
+        Map<String, AttributeValue> attributes =
+                mapper.getTableModel(Basket.class, DynamoDBMapperConfig.DEFAULT).convert(basket);
+        Map<String, AttributeValue> nested = attributes.get("basketItems").getL().get(0).getM();
+
+        // then
+        assertThat(nested.get("category").getS()).isEqualTo("Laptop");
+        assertThat(nested.get("category").getN()).isNull();
+        assertThat(nested).doesNotContainKeys("sequenceNumber", "categoryKey");
+    }
+
+    private DynamoDBMapperTableModel<OrderItem> orderItemModel() {
+        DynamoDBMapper mapper = new DynamoDBMapper(mock(AmazonDynamoDB.class));
+        return mapper.getTableModel(OrderItem.class, DynamoDBMapperConfig.DEFAULT);
+    }
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Link to related issue(s) if applicable. -->

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] New provider implementation
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] Other: ___

## Checklist

- [ ] `mvn clean compile` passes
- [ ] Existing tests pass (`mvn test`)
- [ ] New tests added (if applicable)
- [ ] README updated (if applicable)
- [ ] No credentials, API keys, or secrets in committed files

### Provider-specific (if applicable)

- [ ] Provider interface implemented
- [ ] Descriptor registered via `META-INF/services/`
- [ ] Configuration fields defined in descriptor
- [ ] `README.md` with required configuration documented
- [ ] `LICENSE` file included

### DynamoDB changes (if applicable)

- [ ] Migration path considered for existing data
- [ ] Backward-compatible key lookups added (if range key changed)
- [ ] `DynamoDbSchema.java` updated

## Testing

<!-- How was this tested? LocalStack, unit tests, manual? -->
