### PR TITLE
fix: service order-item lifecycle — delivered on entry, allocation lock, warehouse skip, no splits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pl.commercelink</groupId>
     <artifactId>commercelink</artifactId>
-    <version>2026.07.58</version>
+    <version>2026.07.59</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/src/main/java/pl/commercelink/baskets/BasketItem.java
+++ b/src/main/java/pl/commercelink/baskets/BasketItem.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBDocument;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIgnore;
 import pl.commercelink.inventory.MatchedInventory;
+import pl.commercelink.orders.OrderItem;
 import pl.commercelink.pricelist.AvailabilityAndPrice;
 import pl.commercelink.taxonomy.ProductCategories;
 import pl.commercelink.starter.util.UniqueIdentifierGenerator;
@@ -174,7 +175,7 @@ public class BasketItem {
         BasketItem item = new BasketItem(UniqueIdentifierGenerator.generate(),
                 name,
                 SHIPPING_MFN_CODE,
-                null,
+                OrderItem.DELIVERY_CATEGORY,
                 shippingPrice,
                 0,
                 1,

--- a/src/main/java/pl/commercelink/migration/V007_ServiceFlagMigration.java
+++ b/src/main/java/pl/commercelink/migration/V007_ServiceFlagMigration.java
@@ -1,0 +1,154 @@
+package pl.commercelink.migration;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import pl.commercelink.baskets.Basket;
+import pl.commercelink.baskets.BasketItem;
+import pl.commercelink.baskets.BasketsRepository;
+import pl.commercelink.orders.Order;
+import pl.commercelink.orders.OrderItem;
+import pl.commercelink.orders.OrderItemsRepository;
+import pl.commercelink.orders.OrdersRepository;
+import pl.commercelink.products.CategoryDefinition;
+import pl.commercelink.products.Product;
+import pl.commercelink.products.ProductCatalog;
+import pl.commercelink.products.ProductCatalogRepository;
+import pl.commercelink.products.ProductRepository;
+import pl.commercelink.stores.Store;
+import pl.commercelink.stores.StoresRepository;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+// KNOWN LIMITS of the name matching (services-as-a-flag release): items whose service definition
+// was RENAMED or DELETED before this migration keep the old name and stay unflagged; a product
+// definition sharing its name with a service definition in the same store gets its items
+// over-flagged. Both are inherent to matching by definition NAME, not a stable id.
+@ChangeUnit(id = "V007-service-flag-migration", order = "007", author = "commercelink")
+@RequiredArgsConstructor
+public class V007_ServiceFlagMigration {
+
+    private static final String LEGACY_SERVICES_CATEGORY = "Services";
+
+    private final StoresRepository storesRepository;
+    private final ProductCatalogRepository productCatalogRepository;
+    private final ProductRepository productRepository;
+    private final OrdersRepository ordersRepository;
+    private final OrderItemsRepository orderItemsRepository;
+    private final BasketsRepository basketsRepository;
+
+    @Execution
+    public void migrate() {
+        for (Store store : storesRepository.findAll()) {
+            migrateStore(store.getStoreId());
+        }
+    }
+
+    private void migrateStore(String storeId) {
+        Set<String> serviceNames = new HashSet<>();
+        List<CategoryDefinition> serviceDefinitions = new ArrayList<>();
+
+        List<ProductCatalog> catalogs = productCatalogRepository.findAll(storeId);
+
+        int migratedDefinitions = 0;
+        for (ProductCatalog catalog : catalogs) {
+            boolean dirty = false;
+            for (CategoryDefinition definition : catalog.getCategories()) {
+                boolean legacy = LEGACY_SERVICES_CATEGORY.equals(definition.getCategory());
+                if (legacy) {
+                    serviceDefinitions.add(definition);
+                    if (StringUtils.isNotBlank(definition.getName())) {
+                        serviceNames.add(definition.getName());
+                    }
+                    definition.setCategory(null);
+                    dirty = true;
+                    migratedDefinitions++;
+                }
+            }
+            if (dirty) {
+                productCatalogRepository.save(catalog);
+            }
+        }
+
+        int migratedProducts = 0;
+        for (CategoryDefinition definition : serviceDefinitions) {
+            for (Product product : productRepository.findAll(definition.getCategoryId())) {
+                if (!product.isService()) {
+                    product.setService(true);
+                    migratedProducts++;
+                    productRepository.save(product);
+                }
+            }
+        }
+
+        int migratedOrderItems = 0;
+        for (Order order : ordersRepository.findAll(storeId)) {
+            for (OrderItem item : orderItemsRepository.findByOrderId(order.getOrderId())) {
+                if (migrateItem(item, serviceNames)) {
+                    migratedOrderItems++;
+                    orderItemsRepository.save(item);
+                }
+            }
+        }
+
+        int migratedBasketItems = 0;
+        for (Basket basket : basketsRepository.findAll(storeId)) {
+            if (basket.getBasketItems() == null) {
+                continue;
+            }
+            boolean dirty = false;
+            for (BasketItem item : basket.getBasketItems()) {
+                if (migrateItem(item, serviceNames)) {
+                    migratedBasketItems++;
+                    dirty = true;
+                }
+            }
+            if (dirty) {
+                basketsRepository.save(basket);
+            }
+        }
+
+        System.out.println(storeId + ": definitions=" + migratedDefinitions + ", products=" + migratedProducts
+                + ", orderItems=" + migratedOrderItems + ", basketItems=" + migratedBasketItems);
+    }
+
+    private boolean migrateItem(OrderItem item, Set<String> serviceNames) {
+        boolean changed = false;
+        if (!item.isService() && isLegacyService(item.getCategory(), serviceNames)) {
+            item.setService(true);
+            changed = true;
+        }
+        if (LEGACY_SERVICES_CATEGORY.equals(item.getCategory())) {
+            item.setCategory(null);
+            changed = true;
+        }
+        return changed;
+    }
+
+    private boolean migrateItem(BasketItem item, Set<String> serviceNames) {
+        boolean changed = false;
+        if (!item.isService() && isLegacyService(item.getCategory(), serviceNames)) {
+            item.setService(true);
+            changed = true;
+        }
+        if (LEGACY_SERVICES_CATEGORY.equals(item.getCategory())) {
+            item.setCategory(null);
+            changed = true;
+        }
+        return changed;
+    }
+
+    private boolean isLegacyService(String category, Set<String> serviceNames) {
+        return LEGACY_SERVICES_CATEGORY.equals(category)
+                || (category != null && serviceNames.contains(category));
+    }
+
+    @RollbackExecution
+    public void rollback() {
+    }
+}

--- a/src/main/java/pl/commercelink/orders/OrderItem.java
+++ b/src/main/java/pl/commercelink/orders/OrderItem.java
@@ -83,7 +83,7 @@ public class OrderItem extends Item {
 
     @DynamoDBIgnore
     public boolean hasSupplierAllocation() {
-        return isInAllocation() || (hasAllocationDetails() && hasOneOfTheStatuses(FulfilmentStatus.Ordered, FulfilmentStatus.Delivered));
+        return isInAllocation() || (hasAllocationDetails() && hasOneOfTheStatuses(FulfilmentStatus.Ordered, FulfilmentStatus.Delivered, FulfilmentStatus.Returned, FulfilmentStatus.Replaced));
     }
 
     public void update(OrderItem other) {

--- a/src/main/java/pl/commercelink/orders/OrderItem.java
+++ b/src/main/java/pl/commercelink/orders/OrderItem.java
@@ -273,6 +273,7 @@ public class OrderItem extends Item {
                 basketItem.isConsolidated()
         );
         orderItem.setService(basketItem.isService());
+        orderItem.markAsWarehouseFulfilled();
         orderItem.setPosition(basketItem.getPosition());
         return orderItem;
     }
@@ -289,6 +290,7 @@ public class OrderItem extends Item {
                 PositionGroup.DELIVERY_POSITION
         );
         orderItem.setService(true);
+        orderItem.markAsWarehouseFulfilled();
         return orderItem;
     }
 

--- a/src/main/java/pl/commercelink/orders/OrderItem.java
+++ b/src/main/java/pl/commercelink/orders/OrderItem.java
@@ -84,7 +84,7 @@ public class OrderItem extends Item {
 
     @DynamoDBIgnore
     public boolean hasSupplierAllocation() {
-        return isInAllocation() || (hasAllocationDetails() && hasOneOfTheStatuses(FulfilmentStatus.Ordered, FulfilmentStatus.Delivered, FulfilmentStatus.Returned, FulfilmentStatus.Replaced));
+        return isInAllocation() || (hasAllocationDetails() && hasOneOfTheStatuses(FulfilmentStatus.Ordered, FulfilmentStatus.Delivered, FulfilmentStatus.InExternalService, FulfilmentStatus.Returned, FulfilmentStatus.Replaced));
     }
 
     public void update(OrderItem other) {

--- a/src/main/java/pl/commercelink/orders/OrderItem.java
+++ b/src/main/java/pl/commercelink/orders/OrderItem.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 public class OrderItem extends Item {
 
     public static final String GENERIC_WAREHOUSE_ORDER_NO = "Warehouse";
+    public static final String DELIVERY_CATEGORY = "Dostawa";
 
     @DynamoDBHashKey(attributeName = "orderId")
     private String orderId;
@@ -286,7 +287,7 @@ public class OrderItem extends Item {
     public static OrderItem fromDeliveryOption(String orderId, DeliveryOption opt) {
         OrderItem orderItem = new OrderItem(
                 orderId,
-                null,
+                DELIVERY_CATEGORY,
                 opt.getName(),
                 1,
                 opt.getPrice(),

--- a/src/main/java/pl/commercelink/orders/OrderItem.java
+++ b/src/main/java/pl/commercelink/orders/OrderItem.java
@@ -81,6 +81,11 @@ public class OrderItem extends Item {
         }
     }
 
+    @DynamoDBIgnore
+    public boolean hasSupplierAllocation() {
+        return isInAllocation() || (hasAllocationDetails() && hasOneOfTheStatuses(FulfilmentStatus.Ordered, FulfilmentStatus.Delivered));
+    }
+
     public void update(OrderItem other) {
         if (isNew()) {
             updateAllFields(other);

--- a/src/main/java/pl/commercelink/orders/OrdersManager.java
+++ b/src/main/java/pl/commercelink/orders/OrdersManager.java
@@ -249,7 +249,7 @@ public class OrdersManager {
     public void splitGroupItem(String orderId, String itemId, List<SplitGroupComponent> components) {
         OrderItem source = orderItemsRepository.findById(orderId, itemId);
 
-        if (source == null || !source.isNew()) {
+        if (source == null || !source.isNew() || source.isService()) {
             throw new IllegalStateException("split.group.invalid.state");
         }
         if (components == null || components.size() < 2) {
@@ -276,7 +276,6 @@ public class OrdersManager {
                     source.getPosition()
             );
             newItem.setService(source.isService());
-            newItem.markAsWarehouseFulfilled();
             newItem.setComment(source.getComment());
             orderItemsRepository.save(newItem);
         }

--- a/src/main/java/pl/commercelink/orders/OrdersManager.java
+++ b/src/main/java/pl/commercelink/orders/OrdersManager.java
@@ -145,7 +145,7 @@ public class OrdersManager {
 
     public Result moveOrderItemsToTheWarehouseForRMA(String storeId, String orderId, List<String> orderItemIds) {
         return execute(storeId, orderId, orderItemIds, (order, orderItem) -> {
-            if (orderItem.isDelivered()) {
+            if (orderItem.isProduct() && orderItem.isDelivered()) {
                 warehouse.reservationService(storeId)
                         .remove(
                                 Reservation.orderFulfilmentToRMA(
@@ -163,7 +163,7 @@ public class OrdersManager {
 
     public Result moveOrderItemsToTheWarehouse(String storeId, String orderId, List<String> orderItemIds) {
         return execute(storeId, orderId, orderItemIds, (order, orderItem) -> {
-            if (orderItem.isAllocated()) {
+            if (orderItem.isProduct() && orderItem.isAllocated()) {
                 warehouse.reservationService(storeId)
                         .remove(
                                 Reservation.orderFulfilmentToStock(

--- a/src/main/java/pl/commercelink/orders/OrdersManager.java
+++ b/src/main/java/pl/commercelink/orders/OrdersManager.java
@@ -276,6 +276,7 @@ public class OrdersManager {
                     source.getPosition()
             );
             newItem.setService(source.isService());
+            newItem.markAsWarehouseFulfilled();
             newItem.setComment(source.getComment());
             orderItemsRepository.save(newItem);
         }

--- a/src/main/java/pl/commercelink/web/OrdersController.java
+++ b/src/main/java/pl/commercelink/web/OrdersController.java
@@ -509,10 +509,32 @@ public class OrdersController extends BaseController {
         if (op.isPresent()) {
             OrderItem orderItem = op.get();
 
+            boolean wasService = orderItem.isService();
+            boolean serviceFlagLocked = orderItem.hasSupplierAllocation();
+
             if (StringUtils.isBlank(updatedItem.getCategory())) {
                 updatedItem.setCategory(null);
             }
+            if (serviceFlagLocked) {
+                updatedItem.setService(orderItem.isService());
+            }
             orderItem.update(updatedItem);
+
+            if (!wasService && orderItem.isService()) {
+                orderItem.markAsWarehouseFulfilled();
+                if (orderItem.getPosition() < PositionGroup.SERVICE_GROUP_START) {
+                    orderItem.setPosition(PositionGroup.SERVICE_GROUP_START + orderItem.getPosition());
+                }
+            } else if (wasService && !orderItem.isService()) {
+                if (OrderItem.GENERIC_WAREHOUSE_ORDER_NO.equals(orderItem.getDeliveryId())) {
+                    orderItem.setDeliveryId(null);
+                    orderItem.setStatus(FulfilmentStatus.New);
+                }
+                if (orderItem.getPosition() >= PositionGroup.SERVICE_GROUP_START && orderItem.getPosition() < PositionGroup.DELIVERY_POSITION) {
+                    orderItem.setPosition(orderItem.getPosition() - PositionGroup.SERVICE_GROUP_START);
+                }
+            }
+
             orderItemsRepository.save(orderItem);
 
             order.setTotalPrice(new OrderFinancials(order, orderItems).getTotalPrice());
@@ -615,6 +637,7 @@ public class OrdersController extends BaseController {
         model.addAttribute("categoryGroups", storeCategories.groupsFor(order.getStoreId()));
         model.addAttribute("fulfilmentStatuses", FulfilmentStatus.values());
         model.addAttribute("isCompletedOrder", order.hasOneOfStatuses(OrderStatus.Completed, OrderStatus.Cancelled));
+        model.addAttribute("serviceFlagLocked", orderItem.hasSupplierAllocation());
 
         return "orderItem";
     }

--- a/src/main/resources/local-init/s3/stores/uma2dqukxr/pricelists/cat-local-01/seed.csv
+++ b/src/main/resources/local-init/s3/stores/uma2dqukxr/pricelists/cat-local-01/seed.csv
@@ -1,4 +1,4 @@
-PimId;EAN;Mfn;Brand;Label;Name;Category;Price;Qty;Estimated Delivery Days;Lowest 30 Days Price;service
+PimId;EAN;Mfn;Brand;Label;Name;Category;Price;Qty;Estimated Delivery Days;Lowest 30 Days Price;Service
 local-seed-0001;5900000000001;MFN-CLEAR-01;AMD;AMD ClearEdge;AMD ClearEdge Pro X3D;CPU;1299;20;1;1299;false
 local-seed-0002;5900000000002;MZ-V8V1T0BW;Samsung;Samsung 980;Samsung 980 NVMe 1TB;Storage;299;50;1;319;false
 local-seed-0003;5900000000003;MFN-TWIN-01;G.Skill;TwinMatch DDR5;G.Skill TwinMatch 32GB DDR5 Kit;Memory;459;50;1;479;false

--- a/src/main/resources/templates/orderDetails.html
+++ b/src/main/resources/templates/orderDetails.html
@@ -418,12 +418,12 @@
                                            th:text="#{order.item.clear.assign}"></a>
                                         <span th:unless="${item.isNew() and !item.group}" class="dropdown-item has-text-grey-light" style="cursor: not-allowed;"
                                               th:text="#{order.item.clear.assign}"></span>
-                                        <a th:if="${item.isNew() and item.group}" class="dropdown-item"
+                                        <a th:if="${item.isNew() and item.group and item.product}" class="dropdown-item"
                                            href="#"
                                            th:attr="data-item-id=${item.itemId}"
                                            onclick="openSplitGroupModal(this); return false;"
                                            th:text="#{order.item.split.group}"></a>
-                                        <span th:unless="${item.isNew() and item.group}" class="dropdown-item has-text-grey-light" style="cursor: not-allowed;"
+                                        <span th:unless="${item.isNew() and item.group and item.product}" class="dropdown-item has-text-grey-light" style="cursor: not-allowed;"
                                               th:text="#{order.item.split.group}"></span>
                                         <a class="dropdown-item"
                                            href="#"

--- a/src/main/resources/templates/orderItem.html
+++ b/src/main/resources/templates/orderItem.html
@@ -34,7 +34,7 @@
 
                     <div class="field">
                         <label class="checkbox">
-                            <input type="checkbox" th:field="*{service}" th:disabled="${isCompletedOrder}" />
+                            <input type="checkbox" th:field="*{service}" th:disabled="${isCompletedOrder or serviceFlagLocked}" />
                             <span th:text="#{product.service}"></span>
                         </label>
                     </div>

--- a/src/test/java/pl/commercelink/baskets/BasketItemTest.java
+++ b/src/test/java/pl/commercelink/baskets/BasketItemTest.java
@@ -60,9 +60,13 @@ class BasketItemTest {
     }
 
     @Test
-    void shippingItemHasNoCategoryString() {
+    void shippingItemHasDeliveryCategoryLabel() {
+        // given
+        BasketItem shipping = BasketItem.shipping(10.0);
+
         // when / then
-        assertThat(BasketItem.shipping(10.0).getCategory()).isNull();
+        assertThat(shipping.getCategory()).isEqualTo("Dostawa");
+        assertThat(shipping.isService()).isTrue();
     }
 
     @Test

--- a/src/test/java/pl/commercelink/migration/V007_ServiceFlagMigrationTest.java
+++ b/src/test/java/pl/commercelink/migration/V007_ServiceFlagMigrationTest.java
@@ -1,0 +1,217 @@
+package pl.commercelink.migration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import pl.commercelink.baskets.Basket;
+import pl.commercelink.baskets.BasketItem;
+import pl.commercelink.baskets.BasketsRepository;
+import pl.commercelink.orders.Order;
+import pl.commercelink.orders.OrderItem;
+import pl.commercelink.orders.OrderItemsRepository;
+import pl.commercelink.orders.OrdersRepository;
+import pl.commercelink.products.CategoryDefinition;
+import pl.commercelink.products.Product;
+import pl.commercelink.products.ProductCatalog;
+import pl.commercelink.products.ProductCatalogRepository;
+import pl.commercelink.products.ProductRepository;
+import pl.commercelink.stores.Store;
+import pl.commercelink.stores.StoresRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class V007_ServiceFlagMigrationTest {
+
+    private static final String STORE_ID = "store-1";
+
+    @Mock
+    private StoresRepository storesRepository;
+    @Mock
+    private ProductCatalogRepository productCatalogRepository;
+    @Mock
+    private ProductRepository productRepository;
+    @Mock
+    private OrdersRepository ordersRepository;
+    @Mock
+    private OrderItemsRepository orderItemsRepository;
+    @Mock
+    private BasketsRepository basketsRepository;
+
+    @InjectMocks
+    private V007_ServiceFlagMigration migration;
+
+    private ProductCatalog catalogWithLegacyServicesDefinition(String catalogId, String definitionCategoryId, String definitionName) {
+        CategoryDefinition definition = new CategoryDefinition();
+        definition.setCategoryId(definitionCategoryId);
+        definition.setName(definitionName);
+        definition.setCategory("Services");
+
+        ProductCatalog catalog = new ProductCatalog(STORE_ID, "Catalog");
+        catalog.setCatalogId(catalogId);
+        catalog.setCategories(new ArrayList<>(List.of(definition)));
+        return catalog;
+    }
+
+    @Test
+    void secondRunIsANoOp() {
+        // given
+        ProductCatalog catalog = catalogWithLegacyServicesDefinition("catalog-1", "cat-def-1", "Serwis");
+        when(storesRepository.findAll()).thenReturn(List.of(storeWith(STORE_ID)));
+        when(productCatalogRepository.findAll(STORE_ID)).thenReturn(List.of(catalog));
+
+        Product product = new Product("cat-def-1");
+        product.setService(false);
+        when(productRepository.findAll("cat-def-1")).thenReturn(List.of(product));
+
+        Order order = new Order(STORE_ID);
+        when(ordersRepository.findAll(STORE_ID)).thenReturn(List.of(order));
+
+        OrderItem orderItem = new OrderItem(order.getOrderId(), "Services", "Montaz", 1, 10, "sku-1", false);
+        when(orderItemsRepository.findByOrderId(order.getOrderId())).thenReturn(List.of(orderItem));
+
+        BasketItem basketItem = new BasketItem("id-1", "Montaz", "mfn-1", "Services", 10, 0, 1, "catalog-1", 1, false);
+        Basket basket = new Basket();
+        basket.setStoreId(STORE_ID);
+        basket.setBasketItems(new ArrayList<>(List.of(basketItem)));
+        when(basketsRepository.findAll(STORE_ID)).thenReturn(List.of(basket));
+
+        // when
+        migration.migrate();
+        migration.migrate();
+
+        // then
+        verify(productCatalogRepository, times(1)).save(catalog);
+        verify(productRepository, times(1)).save(product);
+        verify(orderItemsRepository, times(1)).save(orderItem);
+        verify(basketsRepository, times(1)).save(basket);
+
+        assertThat(product.isService()).isTrue();
+        assertThat(orderItem.isService()).isTrue();
+        assertThat(orderItem.getCategory()).isNull();
+        assertThat(basketItem.isService()).isTrue();
+        assertThat(basketItem.getCategory()).isNull();
+    }
+
+    @Test
+    void categoryDefinitionsWithLegacyServicesCategoryAreClearedAndCollected() {
+        // given
+        ProductCatalog catalog = catalogWithLegacyServicesDefinition("catalog-1", "cat-def-1", "Serwis");
+        when(storesRepository.findAll()).thenReturn(List.of(storeWith(STORE_ID)));
+        when(productCatalogRepository.findAll(STORE_ID)).thenReturn(List.of(catalog));
+        when(productRepository.findAll("cat-def-1")).thenReturn(List.of());
+        when(ordersRepository.findAll(STORE_ID)).thenReturn(List.of());
+        when(basketsRepository.findAll(STORE_ID)).thenReturn(List.of());
+
+        // when
+        migration.migrate();
+
+        // then
+        assertThat(catalog.getCategories().get(0).getCategory()).isNull();
+        verify(productCatalogRepository).save(catalog);
+    }
+
+    @Test
+    void productsUnderFormerServiceDefinitionGetFlaggedWhenMissing() {
+        // given
+        ProductCatalog catalog = catalogWithLegacyServicesDefinition("catalog-1", "cat-def-1", "Serwis");
+        when(storesRepository.findAll()).thenReturn(List.of(storeWith(STORE_ID)));
+        when(productCatalogRepository.findAll(STORE_ID)).thenReturn(List.of(catalog));
+
+        Product alreadyFlagged = new Product("cat-def-1");
+        alreadyFlagged.setService(true);
+        Product missingFlag = new Product("cat-def-1");
+        missingFlag.setService(false);
+        when(productRepository.findAll("cat-def-1")).thenReturn(List.of(alreadyFlagged, missingFlag));
+        when(ordersRepository.findAll(STORE_ID)).thenReturn(List.of());
+        when(basketsRepository.findAll(STORE_ID)).thenReturn(List.of());
+
+        // when
+        migration.migrate();
+
+        // then
+        assertThat(alreadyFlagged.isService()).isTrue();
+        assertThat(missingFlag.isService()).isTrue();
+        verify(productRepository, times(1)).save(missingFlag);
+        verify(productRepository, times(0)).save(alreadyFlagged);
+    }
+
+    @Test
+    void orderItemMigrationClearsLegacyCategoryAndFlagsByDefinitionName() {
+        // given
+        ProductCatalog catalog = catalogWithLegacyServicesDefinition("catalog-1", "cat-def-1", "Konsultacje");
+        when(storesRepository.findAll()).thenReturn(List.of(storeWith(STORE_ID)));
+        when(productCatalogRepository.findAll(STORE_ID)).thenReturn(List.of(catalog));
+        when(productRepository.findAll("cat-def-1")).thenReturn(List.of());
+        when(basketsRepository.findAll(STORE_ID)).thenReturn(List.of());
+
+        Order order = new Order(STORE_ID);
+        when(ordersRepository.findAll(STORE_ID)).thenReturn(List.of(order));
+
+        OrderItem alreadyFlaggedLegacyItem = new OrderItem(order.getOrderId(), "Services", "Montaz", 1, 10, "sku-1", false);
+        alreadyFlaggedLegacyItem.setService(true);
+        OrderItem nameMatchedItem = new OrderItem(order.getOrderId(), "Konsultacje", "Doradztwo", 1, 20, "sku-2", false);
+        when(orderItemsRepository.findByOrderId(order.getOrderId())).thenReturn(List.of(alreadyFlaggedLegacyItem, nameMatchedItem));
+
+        // when
+        migration.migrate();
+
+        // then
+        assertThat(alreadyFlaggedLegacyItem.isService()).isTrue();
+        assertThat(alreadyFlaggedLegacyItem.getCategory()).isNull();
+
+        assertThat(nameMatchedItem.isService()).isTrue();
+        assertThat(nameMatchedItem.getCategory()).isEqualTo("Konsultacje");
+
+        verify(orderItemsRepository).save(alreadyFlaggedLegacyItem);
+        verify(orderItemsRepository).save(nameMatchedItem);
+    }
+
+    @Test
+    void basketItemMigrationClearsLegacyCategoryAndFlagsByDefinitionName() {
+        // given
+        ProductCatalog catalog = catalogWithLegacyServicesDefinition("catalog-1", "cat-def-1", "Konsultacje");
+        when(storesRepository.findAll()).thenReturn(List.of(storeWith(STORE_ID)));
+        when(productCatalogRepository.findAll(STORE_ID)).thenReturn(List.of(catalog));
+        when(productRepository.findAll("cat-def-1")).thenReturn(List.of());
+        when(ordersRepository.findAll(STORE_ID)).thenReturn(List.of());
+
+        BasketItem alreadyFlaggedLegacyItem = new BasketItem("id-1", "Montaz", "mfn-1", "Services", 10, 0, 1, "catalog-1", 1, false);
+        alreadyFlaggedLegacyItem.setService(true);
+        BasketItem nameMatchedItem = new BasketItem("id-2", "Doradztwo", "mfn-2", "Konsultacje", 20, 0, 1, "catalog-1", 1, false);
+
+        Basket basket = new Basket();
+        basket.setStoreId(STORE_ID);
+        basket.setBasketItems(new ArrayList<>(List.of(alreadyFlaggedLegacyItem, nameMatchedItem)));
+        when(basketsRepository.findAll(STORE_ID)).thenReturn(List.of(basket));
+
+        // when
+        migration.migrate();
+
+        // then
+        assertThat(alreadyFlaggedLegacyItem.isService()).isTrue();
+        assertThat(alreadyFlaggedLegacyItem.getCategory()).isNull();
+
+        assertThat(nameMatchedItem.isService()).isTrue();
+        assertThat(nameMatchedItem.getCategory()).isEqualTo("Konsultacje");
+
+        verify(basketsRepository).save(basket);
+    }
+
+    private static Store storeWith(String storeId) {
+        Store store = new Store();
+        store.setStoreId(storeId);
+        return store;
+    }
+}

--- a/src/test/java/pl/commercelink/orders/OrderItemTest.java
+++ b/src/test/java/pl/commercelink/orders/OrderItemTest.java
@@ -26,8 +26,8 @@ class OrderItemTest {
     }
 
     @Test
-    @DisplayName("fromDeliveryOption creates a service item without any category string")
-    void fromDeliveryOptionCreatesServiceItemWithoutCategory() {
+    @DisplayName("fromDeliveryOption creates a service item with the delivery category label")
+    void fromDeliveryOptionCreatesServiceItemWithDeliveryCategoryLabel() {
         // given
         DeliveryOption option = new DeliveryOption();
         option.setName("Kurier DPD");
@@ -38,7 +38,7 @@ class OrderItemTest {
 
         // then
         assertThat(deliveryItem.isService()).isTrue();
-        assertThat(deliveryItem.getCategory()).isNull();
+        assertThat(deliveryItem.getCategory()).isEqualTo("Dostawa");
         assertThat(deliveryItem.getPosition()).isEqualTo(PositionGroup.DELIVERY_POSITION);
         assertThat(deliveryItem.getStatus()).isEqualTo(FulfilmentStatus.Delivered);
         assertThat(deliveryItem.getDeliveryId()).isEqualTo(OrderItem.GENERIC_WAREHOUSE_ORDER_NO);

--- a/src/test/java/pl/commercelink/orders/OrderItemTest.java
+++ b/src/test/java/pl/commercelink/orders/OrderItemTest.java
@@ -40,6 +40,39 @@ class OrderItemTest {
         assertThat(deliveryItem.isService()).isTrue();
         assertThat(deliveryItem.getCategory()).isNull();
         assertThat(deliveryItem.getPosition()).isEqualTo(PositionGroup.DELIVERY_POSITION);
+        assertThat(deliveryItem.getStatus()).isEqualTo(FulfilmentStatus.Delivered);
+        assertThat(deliveryItem.getDeliveryId()).isEqualTo(OrderItem.GENERIC_WAREHOUSE_ORDER_NO);
+    }
+
+    @Test
+    @DisplayName("fromBasketItem marks a service item as warehouse-fulfilled on entry")
+    void fromBasketItemMarksServiceItemAsDelivered() {
+        // given
+        BasketItem basketItem = new BasketItem("pim-1", "Montaż PC", "MONTAZ-1", "Usługi dodatkowe", 150, 100, 1, "cat-1", 801, false);
+        basketItem.setService(true);
+
+        // when
+        OrderItem orderItem = OrderItem.fromBasketItem(ORDER_ID, basketItem);
+
+        // then
+        assertThat(orderItem.isService()).isTrue();
+        assertThat(orderItem.getStatus()).isEqualTo(FulfilmentStatus.Delivered);
+        assertThat(orderItem.getDeliveryId()).isEqualTo(OrderItem.GENERIC_WAREHOUSE_ORDER_NO);
+    }
+
+    @Test
+    @DisplayName("fromBasketItem leaves a product item untouched by the service invariant")
+    void fromBasketItemLeavesProductItemNew() {
+        // given
+        BasketItem basketItem = basketItem("MFN-1");
+
+        // when
+        OrderItem orderItem = OrderItem.fromBasketItem(ORDER_ID, basketItem);
+
+        // then
+        assertThat(orderItem.isService()).isFalse();
+        assertThat(orderItem.getStatus()).isEqualTo(FulfilmentStatus.New);
+        assertThat(orderItem.getDeliveryId()).isNull();
     }
 
     @Test

--- a/src/test/java/pl/commercelink/orders/OrderItemTest.java
+++ b/src/test/java/pl/commercelink/orders/OrderItemTest.java
@@ -184,6 +184,20 @@ class OrderItemTest {
         assertThat(orderItem.hasSupplierAllocation()).isTrue();
     }
 
+    @Test
+    @DisplayName("hasSupplierAllocation is true for a product in external service with real allocation details")
+    void hasSupplierAllocationIsTrueForProductInExternalServiceWithAllocationDetails() {
+        // given
+        OrderItem orderItem = orderItem("MFN-1");
+        orderItem.setEan("EAN-1");
+        orderItem.setManufacturerCode("MFN-1");
+        orderItem.setDeliveryId("delivery-1");
+        orderItem.setStatus(FulfilmentStatus.InExternalService);
+
+        // then
+        assertThat(orderItem.hasSupplierAllocation()).isTrue();
+    }
+
     private BasketItem basketItem(String mfn) {
         return new BasketItem("pim-1", "Product", mfn,
                 "Laptops", 100.0, 0, 1, null, 3, false);

--- a/src/test/java/pl/commercelink/orders/OrderItemTest.java
+++ b/src/test/java/pl/commercelink/orders/OrderItemTest.java
@@ -156,6 +156,34 @@ class OrderItemTest {
         assertThat(orderItem.hasSupplierAllocation()).isTrue();
     }
 
+    @Test
+    @DisplayName("hasSupplierAllocation is true for a returned product with real allocation details")
+    void hasSupplierAllocationIsTrueForReturnedProductWithAllocationDetails() {
+        // given
+        OrderItem orderItem = orderItem("MFN-1");
+        orderItem.setEan("EAN-1");
+        orderItem.setManufacturerCode("MFN-1");
+        orderItem.setDeliveryId("delivery-1");
+        orderItem.markAsReturned();
+
+        // then
+        assertThat(orderItem.hasSupplierAllocation()).isTrue();
+    }
+
+    @Test
+    @DisplayName("hasSupplierAllocation is true for a replaced product with real allocation details")
+    void hasSupplierAllocationIsTrueForReplacedProductWithAllocationDetails() {
+        // given
+        OrderItem orderItem = orderItem("MFN-1");
+        orderItem.setEan("EAN-1");
+        orderItem.setManufacturerCode("MFN-1");
+        orderItem.setDeliveryId("delivery-1");
+        orderItem.markAsReplaced();
+
+        // then
+        assertThat(orderItem.hasSupplierAllocation()).isTrue();
+    }
+
     private BasketItem basketItem(String mfn) {
         return new BasketItem("pim-1", "Product", mfn,
                 "Laptops", 100.0, 0, 1, null, 3, false);

--- a/src/test/java/pl/commercelink/orders/OrderItemTest.java
+++ b/src/test/java/pl/commercelink/orders/OrderItemTest.java
@@ -128,6 +128,34 @@ class OrderItemTest {
         assertThat(copy.isService()).isTrue();
     }
 
+    @Test
+    @DisplayName("hasSupplierAllocation is false for a warehouse-fulfilled service item")
+    void hasSupplierAllocationIsFalseForWarehouseFulfilledService() {
+        // given
+        OrderItem orderItem = orderItem("MFN-1");
+        orderItem.setService(true);
+
+        // when
+        orderItem.markAsWarehouseFulfilled();
+
+        // then
+        assertThat(orderItem.hasSupplierAllocation()).isFalse();
+    }
+
+    @Test
+    @DisplayName("hasSupplierAllocation is true for an ordered product with real allocation details")
+    void hasSupplierAllocationIsTrueForOrderedProductWithAllocationDetails() {
+        // given
+        OrderItem orderItem = orderItem("MFN-1");
+        orderItem.setEan("EAN-1");
+        orderItem.setManufacturerCode("MFN-1");
+        orderItem.setDeliveryId("delivery-1");
+        orderItem.setStatus(FulfilmentStatus.Ordered);
+
+        // then
+        assertThat(orderItem.hasSupplierAllocation()).isTrue();
+    }
+
     private BasketItem basketItem(String mfn) {
         return new BasketItem("pim-1", "Product", mfn,
                 "Laptops", 100.0, 0, 1, null, 3, false);

--- a/src/test/java/pl/commercelink/orders/OrdersManagerTest.java
+++ b/src/test/java/pl/commercelink/orders/OrdersManagerTest.java
@@ -387,26 +387,20 @@ class OrdersManagerTest {
     }
 
     @Test
-    @DisplayName("splitGroupItem components of a legacy New service are warehouse-fulfilled")
-    void splitGroupItemHealsLegacyNewServiceComponents() {
+    @DisplayName("splitGroupItem refuses to split a service item regardless of status")
+    void splitGroupItemIgnoresServiceItems() {
         // given
         OrderItem source = new OrderItem(ORDER_ID, "Usługi dodatkowe", "Pakiet montażowy", 1, 100.0, "MONTAZ-A+MONTAZ-B", false);
         source.setService(true);
         when(orderItemsRepository.findById(ORDER_ID, source.getItemId())).thenReturn(source);
 
-        // when
-        ordersManager.splitGroupItem(ORDER_ID, source.getItemId(), List.of(
+        // when / then
+        assertThatThrownBy(() -> ordersManager.splitGroupItem(ORDER_ID, source.getItemId(), List.of(
                 new SplitGroupComponent("MONTAZ-A", "Montaż A", 1, 60.0),
-                new SplitGroupComponent("MONTAZ-B", "Montaż B", 1, 40.0)));
-
-        // then
-        ArgumentCaptor<OrderItem> itemCaptor = ArgumentCaptor.forClass(OrderItem.class);
-        verify(orderItemsRepository, org.mockito.Mockito.times(2)).save(itemCaptor.capture());
-        assertThat(itemCaptor.getAllValues()).allSatisfy(item -> {
-            assertThat(item.isService()).isTrue();
-            assertThat(item.getStatus()).isEqualTo(FulfilmentStatus.Delivered);
-            assertThat(item.getDeliveryId()).isEqualTo(OrderItem.GENERIC_WAREHOUSE_ORDER_NO);
-        });
+                new SplitGroupComponent("MONTAZ-B", "Montaż B", 1, 40.0))))
+                .isInstanceOf(IllegalStateException.class);
+        verify(orderItemsRepository, never()).save(any(OrderItem.class));
+        verify(orderItemsRepository, never()).delete(any(OrderItem.class));
     }
 
     @Test

--- a/src/test/java/pl/commercelink/orders/OrdersManagerTest.java
+++ b/src/test/java/pl/commercelink/orders/OrdersManagerTest.java
@@ -18,6 +18,8 @@ import pl.commercelink.orders.fulfilment.AutomatedOrderFulfilment;
 import pl.commercelink.orders.fulfilment.OrderFulfilmentEventPublisher;
 import pl.commercelink.pricelist.AvailabilityAndPrice;
 import pl.commercelink.stores.Store;
+import pl.commercelink.warehouse.api.Reservation;
+import pl.commercelink.warehouse.api.ReservationService;
 import pl.commercelink.warehouse.api.Warehouse;
 
 import java.util.List;
@@ -29,6 +31,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,6 +59,8 @@ class OrdersManagerTest {
     private Store store;
     @Mock
     private MatchedInventory matchedInventory;
+    @Mock
+    private ReservationService reservationService;
 
     @InjectMocks
     private OrdersManager ordersManager;
@@ -388,6 +393,56 @@ class OrdersManagerTest {
         });
     }
 
+    @Test
+    @DisplayName("moveOrderItemsToTheWarehouse skips service items entirely")
+    void moveToWarehouseSkipsServiceItems() {
+        // given
+        Order order = orderWithTotalPrice(150.0);
+        OrderItem product = allocatedProduct("item-1");
+        OrderItem service = deliveredWarehouseService("item-2");
+        when(ordersRepository.findById(STORE_ID, ORDER_ID)).thenReturn(order);
+        when(orderItemsRepository.findByOrderId(ORDER_ID)).thenReturn(List.of(product, service));
+        when(warehouse.reservationService(STORE_ID)).thenReturn(reservationService);
+
+        // when
+        ordersManager.moveOrderItemsToTheWarehouse(STORE_ID, ORDER_ID, List.of(product.getItemId(), service.getItemId()));
+
+        // then
+        verify(reservationService, times(1)).remove(any(Reservation.class));
+        verify(orderItemsRepository).save(product);
+        verify(orderItemsRepository, never()).save(service);
+        assertThat(product.getStatus()).isEqualTo(FulfilmentStatus.New);
+        assertThat(product.getEan()).isNull();
+        assertThat(product.getDeliveryId()).isNull();
+        assertThat(service.getStatus()).isEqualTo(FulfilmentStatus.Delivered);
+        assertThat(service.getDeliveryId()).isEqualTo(OrderItem.GENERIC_WAREHOUSE_ORDER_NO);
+    }
+
+    @Test
+    @DisplayName("moveOrderItemsToTheWarehouseForRMA skips service items entirely")
+    void moveToWarehouseForRmaSkipsServiceItems() {
+        // given
+        Order order = orderWithTotalPrice(150.0);
+        OrderItem product = allocatedProduct("item-1");
+        OrderItem service = deliveredWarehouseService("item-2");
+        when(ordersRepository.findById(STORE_ID, ORDER_ID)).thenReturn(order);
+        when(orderItemsRepository.findByOrderId(ORDER_ID)).thenReturn(List.of(product, service));
+        when(warehouse.reservationService(STORE_ID)).thenReturn(reservationService);
+
+        // when
+        ordersManager.moveOrderItemsToTheWarehouseForRMA(STORE_ID, ORDER_ID, List.of(product.getItemId(), service.getItemId()));
+
+        // then
+        verify(reservationService, times(1)).remove(any(Reservation.class));
+        verify(orderItemsRepository).save(product);
+        verify(orderItemsRepository, never()).save(service);
+        assertThat(product.getStatus()).isEqualTo(FulfilmentStatus.New);
+        assertThat(product.getEan()).isNull();
+        assertThat(product.getDeliveryId()).isNull();
+        assertThat(service.getStatus()).isEqualTo(FulfilmentStatus.Delivered);
+        assertThat(service.getDeliveryId()).isEqualTo(OrderItem.GENERIC_WAREHOUSE_ORDER_NO);
+    }
+
     private Order orderWithTotalPrice(double totalPrice) {
         Order order = new Order(STORE_ID);
         order.setOrderId(ORDER_ID);
@@ -418,6 +473,21 @@ class OrdersManagerTest {
         OrderItem item = new OrderItem(ORDER_ID, "Usługi dodatkowe", "service", 1, price, null, false);
         item.setService(true);
         item.setItemId(itemId);
+        return item;
+    }
+
+    private OrderItem allocatedProduct(String itemId) {
+        OrderItem item = orderItem(itemId, 100.0);
+        item.setEan("1111111111111");
+        item.setManufacturerCode("MFN-" + itemId);
+        item.setDeliveryId("Supplier-1");
+        item.setStatus(FulfilmentStatus.Delivered);
+        return item;
+    }
+
+    private OrderItem deliveredWarehouseService(String itemId) {
+        OrderItem item = serviceItem(itemId, 50.0);
+        item.markAsWarehouseFulfilled();
         return item;
     }
 }

--- a/src/test/java/pl/commercelink/orders/OrdersManagerTest.java
+++ b/src/test/java/pl/commercelink/orders/OrdersManagerTest.java
@@ -387,27 +387,8 @@ class OrdersManagerTest {
     }
 
     @Test
-    @DisplayName("splitGroupItem components inherit the service flag from the source item")
-    void splitGroupItemComponentsInheritServiceFlag() {
-        // given
-        OrderItem source = new OrderItem(ORDER_ID, "Usługi dodatkowe", "Pakiet montażowy", 1, 100.0, "MONTAZ-A+MONTAZ-B", false);
-        source.setService(true);
-        when(orderItemsRepository.findById(ORDER_ID, source.getItemId())).thenReturn(source);
-
-        // when
-        ordersManager.splitGroupItem(ORDER_ID, source.getItemId(), List.of(
-                new SplitGroupComponent("MONTAZ-A", "Montaż A", 1, 60.0),
-                new SplitGroupComponent("MONTAZ-B", "Montaż B", 1, 40.0)));
-
-        // then
-        ArgumentCaptor<OrderItem> itemCaptor = ArgumentCaptor.forClass(OrderItem.class);
-        verify(orderItemsRepository, org.mockito.Mockito.times(2)).save(itemCaptor.capture());
-        assertThat(itemCaptor.getAllValues()).allSatisfy(item -> assertThat(item.isService()).isTrue());
-    }
-
-    @Test
-    @DisplayName("splitGroupItem components of a service are warehouse-fulfilled immediately")
-    void splitGroupItemServiceComponentsAreDelivered() {
+    @DisplayName("splitGroupItem components of a legacy New service are warehouse-fulfilled")
+    void splitGroupItemHealsLegacyNewServiceComponents() {
         // given
         OrderItem source = new OrderItem(ORDER_ID, "Usługi dodatkowe", "Pakiet montażowy", 1, 100.0, "MONTAZ-A+MONTAZ-B", false);
         source.setService(true);

--- a/src/test/java/pl/commercelink/orders/OrdersManagerTest.java
+++ b/src/test/java/pl/commercelink/orders/OrdersManagerTest.java
@@ -22,6 +22,7 @@ import pl.commercelink.warehouse.api.Reservation;
 import pl.commercelink.warehouse.api.ReservationService;
 import pl.commercelink.warehouse.api.Warehouse;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -349,6 +350,40 @@ class OrdersManagerTest {
         // then
         verify(ordersRepository).delete(order);
         verify(orderLifecycleEventPublisher, never()).publish(any(), any());
+    }
+
+    @Test
+    @DisplayName("a Delivered service item can be removed from the order")
+    void serviceItemCanBeRemovedEvenWhenDelivered() {
+        // given
+        Order order = orderWithTotalPrice(50.0);
+        OrderItem service = deliveredWarehouseService("item-1");
+        when(ordersRepository.findById(STORE_ID, ORDER_ID)).thenReturn(order);
+        when(orderItemsRepository.findByOrderId(ORDER_ID)).thenReturn(new ArrayList<>(List.of(service)));
+
+        // when
+        ordersManager.removeFromOrder(STORE_ID, ORDER_ID, List.of(service.getItemId()));
+
+        // then
+        verify(orderItemsRepository).delete(service);
+        assertThat(order.getTotalPrice()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("a Delivered product item is NOT removable")
+    void deliveredProductItemIsNotRemovable() {
+        // given
+        Order order = orderWithTotalPrice(100.0);
+        OrderItem product = allocatedProduct("item-1");
+        when(ordersRepository.findById(STORE_ID, ORDER_ID)).thenReturn(order);
+        when(orderItemsRepository.findByOrderId(ORDER_ID)).thenReturn(List.of(product));
+
+        // when
+        ordersManager.removeFromOrder(STORE_ID, ORDER_ID, List.of(product.getItemId()));
+
+        // then
+        verify(orderItemsRepository, never()).delete(any(OrderItem.class));
+        assertThat(order.getTotalPrice()).isEqualTo(100.0);
     }
 
     @Test

--- a/src/test/java/pl/commercelink/orders/OrdersManagerTest.java
+++ b/src/test/java/pl/commercelink/orders/OrdersManagerTest.java
@@ -365,6 +365,29 @@ class OrdersManagerTest {
         assertThat(itemCaptor.getAllValues()).allSatisfy(item -> assertThat(item.isService()).isTrue());
     }
 
+    @Test
+    @DisplayName("splitGroupItem components of a service are warehouse-fulfilled immediately")
+    void splitGroupItemServiceComponentsAreDelivered() {
+        // given
+        OrderItem source = new OrderItem(ORDER_ID, "Usługi dodatkowe", "Pakiet montażowy", 1, 100.0, "MONTAZ-A+MONTAZ-B", false);
+        source.setService(true);
+        when(orderItemsRepository.findById(ORDER_ID, source.getItemId())).thenReturn(source);
+
+        // when
+        ordersManager.splitGroupItem(ORDER_ID, source.getItemId(), List.of(
+                new SplitGroupComponent("MONTAZ-A", "Montaż A", 1, 60.0),
+                new SplitGroupComponent("MONTAZ-B", "Montaż B", 1, 40.0)));
+
+        // then
+        ArgumentCaptor<OrderItem> itemCaptor = ArgumentCaptor.forClass(OrderItem.class);
+        verify(orderItemsRepository, org.mockito.Mockito.times(2)).save(itemCaptor.capture());
+        assertThat(itemCaptor.getAllValues()).allSatisfy(item -> {
+            assertThat(item.isService()).isTrue();
+            assertThat(item.getStatus()).isEqualTo(FulfilmentStatus.Delivered);
+            assertThat(item.getDeliveryId()).isEqualTo(OrderItem.GENERIC_WAREHOUSE_ORDER_NO);
+        });
+    }
+
     private Order orderWithTotalPrice(double totalPrice) {
         Order order = new Order(STORE_ID);
         order.setOrderId(ORDER_ID);

--- a/src/test/java/pl/commercelink/orders/imports/BasketOrderImporterTest.java
+++ b/src/test/java/pl/commercelink/orders/imports/BasketOrderImporterTest.java
@@ -16,6 +16,7 @@ import pl.commercelink.baskets.Basket;
 import pl.commercelink.baskets.BasketItem;
 import pl.commercelink.baskets.BasketsRepository;
 import pl.commercelink.orders.BillingDetails;
+import pl.commercelink.orders.FulfilmentStatus;
 import pl.commercelink.orders.Order;
 import pl.commercelink.orders.OrderItem;
 import pl.commercelink.orders.OrdersManager;
@@ -101,6 +102,8 @@ class BasketOrderImporterTest {
         assertThat(deliveryLine.getCategory()).isNull();
         assertThat(deliveryLine.isService()).isTrue();
         assertThat(deliveryLine.getPosition()).isEqualTo(PositionGroup.DELIVERY_POSITION);
+        assertThat(deliveryLine.getStatus()).isEqualTo(FulfilmentStatus.Delivered);
+        assertThat(deliveryLine.getDeliveryId()).isEqualTo("Warehouse");
     }
 
     private Store storeWithDeliveryOption(DeliveryOption deliveryOption) {

--- a/src/test/java/pl/commercelink/orders/imports/BasketOrderImporterTest.java
+++ b/src/test/java/pl/commercelink/orders/imports/BasketOrderImporterTest.java
@@ -99,7 +99,7 @@ class BasketOrderImporterTest {
         assertThat(savedItems).extracting(OrderItem::getPosition).containsExactly(0, 1, PositionGroup.DELIVERY_POSITION);
 
         OrderItem deliveryLine = savedItems.get(savedItems.size() - 1);
-        assertThat(deliveryLine.getCategory()).isNull();
+        assertThat(deliveryLine.getCategory()).isEqualTo("Dostawa");
         assertThat(deliveryLine.isService()).isTrue();
         assertThat(deliveryLine.getPosition()).isEqualTo(PositionGroup.DELIVERY_POSITION);
         assertThat(deliveryLine.getStatus()).isEqualTo(FulfilmentStatus.Delivered);

--- a/src/test/java/pl/commercelink/pricelist/AvailabilityAndPriceCsvTest.java
+++ b/src/test/java/pl/commercelink/pricelist/AvailabilityAndPriceCsvTest.java
@@ -17,6 +17,6 @@ class AvailabilityAndPriceCsvTest {
 
         // then — service is the last column
         assertThat(csv[csv.length - 1]).isEqualTo("true");
-        assertThat(AvailabilityAndPrice.HEADERS[AvailabilityAndPrice.HEADERS.length - 1]).isEqualTo("service");
+        assertThat(AvailabilityAndPrice.HEADERS[AvailabilityAndPrice.HEADERS.length - 1]).isEqualTo("Service");
     }
 }

--- a/src/test/java/pl/commercelink/web/OrdersControllerTest.java
+++ b/src/test/java/pl/commercelink/web/OrdersControllerTest.java
@@ -15,6 +15,7 @@ import org.mockito.quality.Strictness;
 import org.springframework.context.MessageSource;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import pl.commercelink.orders.BillingDetails;
+import pl.commercelink.orders.FulfilmentStatus;
 import pl.commercelink.orders.Order;
 import pl.commercelink.orders.OrderLifecycle;
 import pl.commercelink.orders.OrderLifecycleEventPublisher;
@@ -25,6 +26,7 @@ import pl.commercelink.orders.OrderItem;
 import pl.commercelink.orders.OrderItemsRepository;
 import pl.commercelink.orders.OrdersManager;
 import pl.commercelink.orders.OrdersRepository;
+import pl.commercelink.orders.PositionGroup;
 import pl.commercelink.orders.Shipment;
 import pl.commercelink.orders.ShipmentType;
 import pl.commercelink.orders.ShippingDetails;
@@ -361,6 +363,66 @@ class OrdersControllerTest {
         // then
         assertThat(item.getCategory()).isNull();
         assertThat(item.isService()).isTrue();
+    }
+
+    @Test
+    void turningServiceFlagOnMarksItemDeliveredAndMovesItToServiceBand() {
+        // given
+        OrderItem item = existingOrderItem("Obudowy", false);
+        item.setPosition(2);
+        OrderItem posted = postedOrderItem("Obudowy");
+        posted.setService(true);
+
+        // when
+        ordersController.saveOrderItem(ORDER_ID, item.getItemId(), posted, new ExtendedModelMap());
+
+        // then
+        assertThat(item.isService()).isTrue();
+        assertThat(item.getStatus()).isEqualTo(FulfilmentStatus.Delivered);
+        assertThat(item.getDeliveryId()).isEqualTo(OrderItem.GENERIC_WAREHOUSE_ORDER_NO);
+        assertThat(item.getPosition()).isEqualTo(PositionGroup.SERVICE_GROUP_START + 2);
+    }
+
+    @Test
+    void turningServiceFlagOffResetsWarehouseFulfilledItemToNewProduct() {
+        // given
+        OrderItem item = existingOrderItem("Usługi", true);
+        item.setDeliveryId(OrderItem.GENERIC_WAREHOUSE_ORDER_NO);
+        item.setStatus(FulfilmentStatus.Delivered);
+        item.setPosition(PositionGroup.SERVICE_GROUP_START + 2);
+        OrderItem posted = postedOrderItem("Usługi");
+        posted.setService(false);
+
+        // when
+        ordersController.saveOrderItem(ORDER_ID, item.getItemId(), posted, new ExtendedModelMap());
+
+        // then
+        assertThat(item.isService()).isFalse();
+        assertThat(item.getStatus()).isEqualTo(FulfilmentStatus.New);
+        assertThat(item.getDeliveryId()).isNull();
+        assertThat(item.getPosition()).isEqualTo(2);
+    }
+
+    @Test
+    void postedServiceFlagIsIgnoredWhenItemHasSupplierAllocation() {
+        // given
+        OrderItem item = existingOrderItem("Laptopy", false);
+        item.setEan("EAN-1");
+        item.setManufacturerCode("MFN-1");
+        item.setDeliveryId("delivery-1");
+        item.setStatus(FulfilmentStatus.Ordered);
+        item.setPosition(2);
+        OrderItem posted = postedOrderItem("Laptopy");
+        posted.setService(true);
+
+        // when
+        ordersController.saveOrderItem(ORDER_ID, item.getItemId(), posted, new ExtendedModelMap());
+
+        // then
+        assertThat(item.isService()).isFalse();
+        assertThat(item.getStatus()).isEqualTo(FulfilmentStatus.Ordered);
+        assertThat(item.getDeliveryId()).isEqualTo("delivery-1");
+        assertThat(item.getPosition()).isEqualTo(2);
     }
 
     private OrderItem existingOrderItem(String category, boolean service) {


### PR DESCRIPTION
Follow-up to #111 addressing the service-lifecycle issues reported after the merge. A service item now behaves consistently as "delivered on arrival, never in the warehouse, deletable anytime, never split".

## What changed

**1. Services are Delivered the moment they enter an order — on every path.**
Previously only `OrdersManager.addOrderItem` enforced this; items created via checkout (`OrderItem.fromBasketItem`), the delivery line (`fromDeliveryOption`) and group splits entered as `New`. A `New` service was picked up by manual fulfilment as if it needed supplier assignment, and a single `New` service held back the computed status of the whole order (`OrderLifecycle` uses `allMatch`). All creation paths now call the self-guarded `markAsWarehouseFulfilled()` (no-op for products): status `Delivered`, deliveryId `Warehouse`.

**2. The "service" checkbox on the order-item edit form is locked once a real supplier allocation exists.**
New predicate `OrderItem.hasSupplierAllocation()` — allocation details (EAN + MFN + deliveryId) combined with status `Ordered`/`Delivered`/`Returned`/`Replaced`/`InExternalService`, or an in-progress allocation. Locked in the template AND server-side (a disabled checkbox still posts `false` through the hidden `_service` marker, so the server guard is the real protection). A service delivered via the warehouse sentinel has no EAN, so its flag stays editable. Toggling ON marks the item Delivered and moves it into the service position band; toggling OFF resets it to `New` (product pipeline) with exact inverse position math — the delivery line at position 999 is never affected.

**3. Warehouse moves ignore services.**
`Item.isAllocated()` deliberately returns `true` for a Delivered service, so both `moveOrderItemsToTheWarehouse` and `moveOrderItemsToTheWarehouseForRMA` passed services through their guards and attempted stock-reservation operations on items with no EAN/MFN. Both now skip non-products silently; products behave exactly as before.

**4. Removing a Delivered service is possible (regression-tested).**
`removeFromOrder` already allowed it (`isNew() || isService()`); the rule is now pinned by tests in both directions (Delivered service removable, Delivered product not). Note: on production data this works only after the one-off service-flag migration has run — unmigrated legacy services carry no flag and are products to this code.

**5. Splitting service items is explicitly forbidden.**
Per product decision: nobody splits services and it must not be possible. The split guard rejects service sources in any status (closing the residual legacy-data window) and the split button is not rendered for services.

**6. Delivery lines carry a readable category label.**
`OrderItem.DELIVERY_CATEGORY = "Dostawa"` (display-only; no logic branches on it) — the order-items table shows a name again instead of an empty cell.

## Also in this PR

- **`V007_ServiceFlagMigration` (Mongock ChangeUnit)** — the one-off service-flag data migration now ships with the release and runs automatically at startup, exactly once per environment (`AppMigrationsHistory` + `mongockLock`), before the app serves traffic — the deploy/migration maintenance window disappears. Per store: legacy `"Services"` mappings cleared from category definitions, products under them flagged, order items (ALL orders, incl. closed) and basket items healed (flag set by string/name match; the literal `"Services"` category cleared even when the flag was already set). Idempotent by construction; per-item `save()` so partial failures surface honestly and a redeploy resumes. The S3 pricelist backfill was dropped by product decision (new pricelists are regenerated nightly and will carry the flag once products are migrated). Known limits of the name matching are documented in the class header.
- `test: align pricelist header expectations with capitalized Service column` — fixes the two tests left red on main by 36b0e4d (test literal and committed seed CSV header aligned to `"Service"`; production constant untouched).
- Version bump `2026.07.58` → `2026.07.59`.

## Testing

Full suite green (851+ tests, 0 failures). Every fix was developed test-first; regression tests cover each reported issue, including the previously untested guard holes (Returned/Replaced/InExternalService allocation lock, warehouse-move service skip).

## Release note

No manual migration step: `V007_ServiceFlagMigration` runs automatically during the first startup of this release (the previously shared `ServiceFlagMigrationController` file is obsolete — do not add it to the deployment package). Startup of the first deploy will take longer than usual (the migration scans all stores' orders and baskets); per-store counts are printed to the log. Old pricelist files are intentionally not touched — offers created before the release keep reading their original pricelists until the nightly regeneration produces flagged ones.
