### PR TITLE
feat: registration email in company details + registration date on stores list (2026.07.60)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pl.commercelink</groupId>
     <artifactId>commercelink</artifactId>
-    <version>2026.07.59</version>
+    <version>2026.07.60</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/src/main/java/pl/commercelink/migration/V008_BackfillStoreRegistrationData.java
+++ b/src/main/java/pl/commercelink/migration/V008_BackfillStoreRegistrationData.java
@@ -1,0 +1,83 @@
+package pl.commercelink.migration;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static pl.commercelink.starter.migration.DynamoDbMigrationSupport.executeUpdate;
+import static pl.commercelink.starter.migration.DynamoDbMigrationSupport.scanAndProcess;
+
+@ChangeUnit(id = "V008-backfill-store-registration-data", order = "008", author = "commercelink")
+@RequiredArgsConstructor
+public class V008_BackfillStoreRegistrationData {
+
+    private static final String TABLE_NAME = "Stores";
+
+    private final AmazonDynamoDB dynamoDB;
+
+    @Execution
+    public void backfillRegistrationData() {
+        scanAndProcess(dynamoDB, TABLE_NAME, List.of("storeId", "demo", "billingDetails", "createdAt"), item -> {
+            BackfillUpdate update = buildUpdate(item);
+            if (update != null) {
+                executeUpdate(dynamoDB, TABLE_NAME, Map.of("storeId", item.get("storeId")),
+                        update.expression(), null, update.values());
+            }
+        });
+    }
+
+    static BackfillUpdate buildUpdate(Map<String, AttributeValue> item) {
+        AttributeValue demo = item.get("demo");
+        if (demo == null || demo.getM() == null) {
+            return null;
+        }
+        List<String> clauses = new ArrayList<>();
+        Map<String, AttributeValue> values = new HashMap<>();
+
+        String ownerEmail = stringValue(demo.getM().get("ownerEmail"));
+        AttributeValue billingDetails = item.get("billingDetails");
+        if (ownerEmail != null) {
+            if (billingDetails == null || billingDetails.getM() == null) {
+                clauses.add("billingDetails = if_not_exists(billingDetails, :billing)");
+                values.put(":billing", new AttributeValue().withM(
+                        Map.of("email", new AttributeValue().withS(ownerEmail))));
+            } else if (stringValue(billingDetails.getM().get("email")) == null) {
+                clauses.add("billingDetails.email = if_not_exists(billingDetails.email, :email)");
+                values.put(":email", new AttributeValue().withS(ownerEmail));
+            }
+        }
+
+        String demoCreatedAt = stringValue(demo.getM().get("createdAt"));
+        if (demoCreatedAt != null && stringValue(item.get("createdAt")) == null) {
+            clauses.add("createdAt = if_not_exists(createdAt, :createdAt)");
+            values.put(":createdAt", new AttributeValue().withS(demoCreatedAt));
+        }
+
+        if (clauses.isEmpty()) {
+            return null;
+        }
+        return new BackfillUpdate("SET " + String.join(", ", clauses), values);
+    }
+
+    private static String stringValue(AttributeValue attribute) {
+        if (attribute == null || attribute.getS() == null || attribute.getS().isBlank()) {
+            return null;
+        }
+        return attribute.getS();
+    }
+
+    record BackfillUpdate(String expression, Map<String, AttributeValue> values) {
+    }
+
+    @RollbackExecution
+    public void rollback() {
+    }
+}

--- a/src/main/java/pl/commercelink/registration/RegistrationService.java
+++ b/src/main/java/pl/commercelink/registration/RegistrationService.java
@@ -115,7 +115,7 @@ public class RegistrationService {
     private RegistrationResult registerProduction(String email, String storeName) {
         Store store;
         try {
-            store = storeCreationService.createStore(CreateStoreRequest.bare(storeName, null));
+            store = storeCreationService.createStore(CreateStoreRequest.registered(storeName, email));
         } catch (RuntimeException e) {
             System.err.println("[Registration] Store creation failed for " + email + ": " + e.getMessage());
             throw new RegistrationException(RegistrationException.Reason.CREATION_FAILED);

--- a/src/main/java/pl/commercelink/stores/CreateStoreRequest.java
+++ b/src/main/java/pl/commercelink/stores/CreateStoreRequest.java
@@ -1,17 +1,21 @@
 package pl.commercelink.stores;
 
 public record CreateStoreRequest(String name, String apiKey, DemoStoreMetadata demoMetadata, StoreSeeder seeder,
-                                 boolean welcomeNotification) {
+                                 boolean welcomeNotification, String ownerEmail) {
 
     public static CreateStoreRequest bare(String name, String apiKey) {
         return bare(name, apiKey, true);
     }
 
     public static CreateStoreRequest bare(String name, String apiKey, boolean welcomeNotification) {
-        return new CreateStoreRequest(name, apiKey, null, null, welcomeNotification);
+        return new CreateStoreRequest(name, apiKey, null, null, welcomeNotification, null);
+    }
+
+    public static CreateStoreRequest registered(String name, String ownerEmail) {
+        return new CreateStoreRequest(name, null, null, null, true, ownerEmail);
     }
 
     public static CreateStoreRequest seeded(String name, DemoStoreMetadata demoMetadata, StoreSeeder seeder) {
-        return new CreateStoreRequest(name, null, demoMetadata, seeder, false);
+        return new CreateStoreRequest(name, null, demoMetadata, seeder, false, demoMetadata.getOwnerEmail());
     }
 }

--- a/src/main/java/pl/commercelink/stores/StoreCreationService.java
+++ b/src/main/java/pl/commercelink/stores/StoreCreationService.java
@@ -1,7 +1,9 @@
 package pl.commercelink.stores;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+import pl.commercelink.orders.BillingDetails;
 import pl.commercelink.starter.util.UniqueIdentifierGenerator;
 
 import java.time.Instant;
@@ -20,6 +22,11 @@ public class StoreCreationService {
         store.setName(request.name());
         store.setApiKey(request.apiKey());
         store.setCreatedAt(Instant.now().toString());
+        if (StringUtils.isNotBlank(request.ownerEmail())) {
+            BillingDetails billingDetails = new BillingDetails();
+            billingDetails.setEmail(request.ownerEmail());
+            store.setBillingDetails(billingDetails);
+        }
         if (request.demoMetadata() != null) {
             store.setDemo(request.demoMetadata());
         }

--- a/src/main/java/pl/commercelink/web/SuperAdminController.java
+++ b/src/main/java/pl/commercelink/web/SuperAdminController.java
@@ -45,9 +45,14 @@ public class SuperAdminController {
     boolean demoEnvironment;
 
     @GetMapping("/dashboard/stores")
-    public String store(Model model) {
-        List<Store> stores = storesRepository.findAll();
+    public String store(@RequestParam(defaultValue = "desc") String dir, Model model) {
+        boolean ascending = "asc".equalsIgnoreCase(dir);
+        Comparator<String> order = ascending ? Comparator.naturalOrder() : Comparator.reverseOrder();
+        List<Store> stores = storesRepository.findAll().stream()
+                .sorted(Comparator.comparing(Store::getCreatedAt, Comparator.nullsLast(order)))
+                .toList();
         model.addAttribute("stores", stores);
+        model.addAttribute("dir", ascending ? "asc" : "desc");
         return "stores";
     }
 

--- a/src/main/resources/application-demo.properties
+++ b/src/main/resources/application-demo.properties
@@ -1,2 +1,3 @@
 app.registration.enabled=true
 app.registration.demo=true
+app.registration.ttl-days=7

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -651,6 +651,7 @@ store.notification.severity=Severity
 store.notification.type=Type
 store.notification.message=Message
 store.id=Store ID
+store.createdAt=Registration Date
 store.name.placeholder=Enter store name
 store.logo=Store Logo
 store.choose.file=Choose a file

--- a/src/main/resources/messages_pl.properties
+++ b/src/main/resources/messages_pl.properties
@@ -640,6 +640,7 @@ store.notification.severity=Istotliwo\u015b\u0107
 store.notification.type=Typ
 store.notification.message=Wiadomo\u015b\u0107
 store.id=ID sklepu
+store.createdAt=Data rejestracji
 store.name.placeholder=Wprowad\u017a nazw\u0119 sklepu
 store.logo=Logo
 store.choose.file=Wybierz plik

--- a/src/main/resources/templates/stores.html
+++ b/src/main/resources/templates/stores.html
@@ -12,6 +12,12 @@
                 <tr>
                     <th th:text="#{store.id}"></th>
                     <th th:text="#{store.name}"></th>
+                    <th>
+                        <a th:href="@{/dashboard/stores(dir=${dir == 'asc'} ? 'desc' : 'asc')}">
+                            <span th:text="#{store.createdAt}"></span>
+                            <span th:text="${dir == 'asc'} ? '▲' : '▼'"></span>
+                        </a>
+                    </th>
                     <th></th>
                 </tr>
                 </thead>
@@ -21,6 +27,7 @@
                         <a th:href="@{'/dashboard/store/' + ${store.storeId}}" th:text="${store.storeId}"></a>
                     </td>
                     <td th:text="${store.name}"></td>
+                    <td th:text="${store.createdAt != null and #strings.length(store.createdAt) >= 10} ? ${#strings.substring(store.createdAt, 0, 10)} : ''"></td>
                     <td th:with="deleteConfirm=${store.demo != null} ? #{store.delete.confirm} : #{store.delete.confirm.regular}">
                         <div th:if="${store.demo != null}" style="display:inline-block">
                             <span class="tag is-warning" th:text="#{store.demo.badge}"></span>

--- a/src/test/java/pl/commercelink/migration/V008_BackfillStoreRegistrationDataTest.java
+++ b/src/test/java/pl/commercelink/migration/V008_BackfillStoreRegistrationDataTest.java
@@ -1,0 +1,161 @@
+package pl.commercelink.migration;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ScanRequest;
+import com.amazonaws.services.dynamodbv2.model.ScanResult;
+import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class V008_BackfillStoreRegistrationDataTest {
+
+    @Mock
+    private AmazonDynamoDB dynamoDB;
+    @InjectMocks
+    private V008_BackfillStoreRegistrationData migration;
+
+    private static AttributeValue string(String value) {
+        return new AttributeValue().withS(value);
+    }
+
+    private static AttributeValue demo(String ownerEmail, String createdAt) {
+        Map<String, AttributeValue> demo = new HashMap<>();
+        if (ownerEmail != null) {
+            demo.put("ownerEmail", string(ownerEmail));
+        }
+        if (createdAt != null) {
+            demo.put("createdAt", string(createdAt));
+        }
+        return new AttributeValue().withM(demo);
+    }
+
+    @Test
+    void backfillsEmailAndCreatedAtWhenBothMissing() {
+        // given
+        Map<String, AttributeValue> item = Map.of(
+                "storeId", string("store-1"),
+                "demo", demo("a@b.pl", "2026-07-01T10:00:00Z"));
+
+        // when
+        V008_BackfillStoreRegistrationData.BackfillUpdate update =
+                V008_BackfillStoreRegistrationData.buildUpdate(item);
+
+        // then
+        assertEquals("SET billingDetails = if_not_exists(billingDetails, :billing), " +
+                "createdAt = if_not_exists(createdAt, :createdAt)", update.expression());
+        assertEquals("a@b.pl", update.values().get(":billing").getM().get("email").getS());
+        assertEquals("2026-07-01T10:00:00Z", update.values().get(":createdAt").getS());
+    }
+
+    @Test
+    void setsNestedEmailWhenBillingDetailsExistsWithoutEmail() {
+        // given
+        Map<String, AttributeValue> item = Map.of(
+                "storeId", string("store-1"),
+                "demo", demo("a@b.pl", null),
+                "createdAt", string("2026-07-01T10:00:00Z"),
+                "billingDetails", new AttributeValue().withM(Map.of("city", string("Kraków"))));
+
+        // when
+        V008_BackfillStoreRegistrationData.BackfillUpdate update =
+                V008_BackfillStoreRegistrationData.buildUpdate(item);
+
+        // then
+        assertEquals("SET billingDetails.email = if_not_exists(billingDetails.email, :email)", update.expression());
+        assertEquals("a@b.pl", update.values().get(":email").getS());
+    }
+
+    @Test
+    void backfillsOnlyCreatedAtWhenBillingComplete() {
+        // given
+        Map<String, AttributeValue> item = Map.of(
+                "storeId", string("store-1"),
+                "demo", demo("a@b.pl", "2026-07-01T10:00:00Z"),
+                "billingDetails", new AttributeValue().withM(Map.of("email", string("x@y.pl"))));
+
+        // when
+        V008_BackfillStoreRegistrationData.BackfillUpdate update =
+                V008_BackfillStoreRegistrationData.buildUpdate(item);
+
+        // then
+        assertEquals("SET createdAt = if_not_exists(createdAt, :createdAt)", update.expression());
+        assertEquals("2026-07-01T10:00:00Z", update.values().get(":createdAt").getS());
+    }
+
+    @Test
+    void skipsStoreWithCompleteData() {
+        // given
+        Map<String, AttributeValue> item = Map.of(
+                "storeId", string("store-1"),
+                "demo", demo("a@b.pl", "2026-07-01T10:00:00Z"),
+                "createdAt", string("2026-07-01T10:00:00Z"),
+                "billingDetails", new AttributeValue().withM(Map.of("email", string("a@b.pl"))));
+
+        // when / then
+        assertNull(V008_BackfillStoreRegistrationData.buildUpdate(item));
+    }
+
+    @Test
+    void skipsNonDemoStore() {
+        // given
+        Map<String, AttributeValue> item = Map.of("storeId", string("store-1"));
+
+        // when / then
+        assertNull(V008_BackfillStoreRegistrationData.buildUpdate(item));
+    }
+
+    @Test
+    void skipsEmailClauseForBlankOwnerEmail() {
+        // given
+        Map<String, AttributeValue> item = Map.of(
+                "storeId", string("store-1"),
+                "demo", demo(" ", "2026-07-01T10:00:00Z"));
+
+        // when
+        V008_BackfillStoreRegistrationData.BackfillUpdate update =
+                V008_BackfillStoreRegistrationData.buildUpdate(item);
+
+        // then
+        assertEquals("SET createdAt = if_not_exists(createdAt, :createdAt)", update.expression());
+        assertFalse(update.values().containsKey(":billing"));
+    }
+
+    @Test
+    void executesUpdateOnlyForStoresNeedingBackfill() {
+        // given
+        Map<String, AttributeValue> needsBackfill = Map.of(
+                "storeId", string("store-1"),
+                "demo", demo("a@b.pl", "2026-07-01T10:00:00Z"));
+        Map<String, AttributeValue> complete = Map.of(
+                "storeId", string("store-2"),
+                "demo", demo("c@d.pl", "2026-07-02T10:00:00Z"),
+                "createdAt", string("2026-07-02T10:00:00Z"),
+                "billingDetails", new AttributeValue().withM(Map.of("email", string("c@d.pl"))));
+        when(dynamoDB.scan(any(ScanRequest.class)))
+                .thenReturn(new ScanResult().withItems(List.of(needsBackfill, complete)));
+
+        // when
+        migration.backfillRegistrationData();
+
+        // then
+        ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(dynamoDB).updateItem(captor.capture());
+        assertEquals("Stores", captor.getValue().getTableName());
+        assertEquals("store-1", captor.getValue().getKey().get("storeId").getS());
+        assertTrue(captor.getValue().getUpdateExpression().startsWith("SET billingDetails"));
+    }
+}

--- a/src/test/java/pl/commercelink/registration/RegistrationServiceTest.java
+++ b/src/test/java/pl/commercelink/registration/RegistrationServiceTest.java
@@ -63,6 +63,7 @@ class RegistrationServiceTest {
         verify(storeCreationService).createStore(requestCaptor.capture());
         assertEquals("Sklep Testowy", requestCaptor.getValue().name());
         assertSame(storeSeeder, requestCaptor.getValue().seeder());
+        assertEquals("user@example.com", requestCaptor.getValue().ownerEmail());
         assertEquals("user@example.com", requestCaptor.getValue().demoMetadata().getOwnerEmail());
         assertEquals(NOW.toString(), requestCaptor.getValue().demoMetadata().getCreatedAt());
         assertEquals(NOW.plusSeconds(14 * 24 * 3600).toString(), requestCaptor.getValue().demoMetadata().getExpiresAt());
@@ -221,7 +222,7 @@ class RegistrationServiceTest {
         // given
         when(rateLimiter.tryAcquire("10.0.0.1")).thenReturn(true);
         when(cognitoUserService.userExists("user@firma.pl")).thenReturn(false);
-        when(storeCreationService.createStore(CreateStoreRequest.bare("Moja Firma", null))).thenReturn(store("prod-store-1"));
+        when(storeCreationService.createStore(CreateStoreRequest.registered("Moja Firma", "user@firma.pl"))).thenReturn(store("prod-store-1"));
 
         // when
         RegistrationResult result = service(false, false).register("user@firma.pl", "Moja Firma", "10.0.0.1");
@@ -229,7 +230,7 @@ class RegistrationServiceTest {
         // then
         assertEquals("prod-store-1", result.storeId());
         assertNull(result.revealedPassword());
-        verify(storeCreationService).createStore(CreateStoreRequest.bare("Moja Firma", null));
+        verify(storeCreationService).createStore(CreateStoreRequest.registered("Moja Firma", "user@firma.pl"));
         verify(cognitoUserService).createStoreAdmin("user@firma.pl", "prod-store-1");
         verifyNoInteractions(storeSeeder);
     }
@@ -239,13 +240,13 @@ class RegistrationServiceTest {
         // given
         when(rateLimiter.tryAcquire("10.0.0.1")).thenReturn(true);
         when(cognitoUserService.userExists("user@firma.pl")).thenReturn(false);
-        when(storeCreationService.createStore(CreateStoreRequest.bare("Moja Firma", null))).thenReturn(store("prod-store-1"));
+        when(storeCreationService.createStore(CreateStoreRequest.registered("Moja Firma", "user@firma.pl"))).thenReturn(store("prod-store-1"));
 
         // when
         service(false, false).register("user@firma.pl", "  Moja Firma  ", "10.0.0.1");
 
         // then
-        verify(storeCreationService).createStore(CreateStoreRequest.bare("Moja Firma", null));
+        verify(storeCreationService).createStore(CreateStoreRequest.registered("Moja Firma", "user@firma.pl"));
     }
 
     @Test
@@ -291,16 +292,16 @@ class RegistrationServiceTest {
         String maxName = "x".repeat(60);
         when(rateLimiter.tryAcquire("10.0.0.1")).thenReturn(true);
         when(cognitoUserService.userExists("user@firma.pl")).thenReturn(false);
-        when(storeCreationService.createStore(CreateStoreRequest.bare(minName, null))).thenReturn(store("prod-store-1"));
-        when(storeCreationService.createStore(CreateStoreRequest.bare(maxName, null))).thenReturn(store("prod-store-2"));
+        when(storeCreationService.createStore(CreateStoreRequest.registered(minName, "user@firma.pl"))).thenReturn(store("prod-store-1"));
+        when(storeCreationService.createStore(CreateStoreRequest.registered(maxName, "user@firma.pl"))).thenReturn(store("prod-store-2"));
 
         // when
         service(false, false).register("user@firma.pl", minName, "10.0.0.1");
         service(false, false).register("user@firma.pl", maxName, "10.0.0.1");
 
         // then
-        verify(storeCreationService).createStore(CreateStoreRequest.bare(minName, null));
-        verify(storeCreationService).createStore(CreateStoreRequest.bare(maxName, null));
+        verify(storeCreationService).createStore(CreateStoreRequest.registered(minName, "user@firma.pl"));
+        verify(storeCreationService).createStore(CreateStoreRequest.registered(maxName, "user@firma.pl"));
     }
 
     @Test
@@ -310,7 +311,7 @@ class RegistrationServiceTest {
                 storeDeletionService, new RegistrationRateLimiter(Clock.fixed(NOW, ZoneOffset.UTC), 3, 100),
                 Clock.fixed(NOW, ZoneOffset.UTC), 14, false, false);
         when(cognitoUserService.userExists("user@firma.pl")).thenReturn(false);
-        when(storeCreationService.createStore(CreateStoreRequest.bare("Moja Firma", null))).thenReturn(store("prod-store-1"));
+        when(storeCreationService.createStore(CreateStoreRequest.registered("Moja Firma", "user@firma.pl"))).thenReturn(store("prod-store-1"));
 
         // when
         for (int i = 0; i < 3; i++) {
@@ -329,7 +330,7 @@ class RegistrationServiceTest {
         // given
         when(rateLimiter.tryAcquire("10.0.0.1")).thenReturn(true);
         when(cognitoUserService.userExists("user@firma.pl")).thenReturn(false);
-        when(storeCreationService.createStore(CreateStoreRequest.bare("Moja Firma", null))).thenReturn(store("prod-store-1"));
+        when(storeCreationService.createStore(CreateStoreRequest.registered("Moja Firma", "user@firma.pl"))).thenReturn(store("prod-store-1"));
 
         // when
         RegistrationResult result = service(false, true).register("user@firma.pl", "Moja Firma", "10.0.0.1");
@@ -344,7 +345,7 @@ class RegistrationServiceTest {
         // given
         when(rateLimiter.tryAcquire("10.0.0.1")).thenReturn(true);
         when(cognitoUserService.userExists("user@firma.pl")).thenReturn(false);
-        when(storeCreationService.createStore(CreateStoreRequest.bare("Moja Firma", null)))
+        when(storeCreationService.createStore(CreateStoreRequest.registered("Moja Firma", "user@firma.pl")))
                 .thenThrow(new RuntimeException("dynamo down"));
 
         // when / then
@@ -361,7 +362,7 @@ class RegistrationServiceTest {
         // given
         when(rateLimiter.tryAcquire("10.0.0.1")).thenReturn(true);
         when(cognitoUserService.userExists("user@firma.pl")).thenReturn(false);
-        when(storeCreationService.createStore(CreateStoreRequest.bare("Moja Firma", null))).thenReturn(store("prod-store-1"));
+        when(storeCreationService.createStore(CreateStoreRequest.registered("Moja Firma", "user@firma.pl"))).thenReturn(store("prod-store-1"));
         doThrow(new RuntimeException("cognito down")).when(cognitoUserService).createStoreAdmin(anyString(), anyString());
 
         // when / then

--- a/src/test/java/pl/commercelink/stores/StoreCreationServiceTest.java
+++ b/src/test/java/pl/commercelink/stores/StoreCreationServiceTest.java
@@ -153,4 +153,43 @@ class StoreCreationServiceTest {
         assertTrue(store.getNotifications().stream()
                 .noneMatch(n -> n.getType() == StoreNotificationType.WELCOME));
     }
+
+    @Test
+    void setsRegistrationEmailAsBillingEmail() {
+        // given
+        when(storesRepository.findById(anyString())).thenReturn(null);
+
+        // when
+        Store store = service.createStore(CreateStoreRequest.registered("Sklep X", "owner@example.com"));
+
+        // then
+        assertNotNull(store.getBillingDetails());
+        assertEquals("owner@example.com", store.getBillingDetails().getEmail());
+    }
+
+    @Test
+    void copiesDemoOwnerEmailToBillingEmail() {
+        // given
+        when(storesRepository.findById(anyString())).thenReturn(null);
+        DemoStoreMetadata demo = new DemoStoreMetadata("a@b.pl", "2026-07-13T10:00:00Z", "2026-07-16T10:00:00Z");
+
+        // when
+        Store store = service.createStore(CreateStoreRequest.seeded("Sklep demo", demo, seeder));
+
+        // then
+        assertNotNull(store.getBillingDetails());
+        assertEquals("a@b.pl", store.getBillingDetails().getEmail());
+    }
+
+    @Test
+    void leavesBillingDetailsEmptyWithoutOwnerEmail() {
+        // given
+        when(storesRepository.findById(anyString())).thenReturn(null);
+
+        // when
+        Store store = service.createStore(CreateStoreRequest.bare("Sklep X", null));
+
+        // then
+        assertNull(store.getBillingDetails());
+    }
 }

--- a/src/test/java/pl/commercelink/web/SuperAdminControllerTest.java
+++ b/src/test/java/pl/commercelink/web/SuperAdminControllerTest.java
@@ -6,6 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.MessageSource;
+import org.springframework.ui.ConcurrentModel;
 import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
 import pl.commercelink.products.OrphanedProductCleanupService;
 import pl.commercelink.stores.CreateStoreRequest;
@@ -15,6 +16,7 @@ import pl.commercelink.stores.StoreCreationService;
 import pl.commercelink.stores.StoreDeletionService;
 import pl.commercelink.stores.StoresRepository;
 
+import java.util.List;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -238,5 +240,64 @@ class SuperAdminControllerTest {
         assertEquals("redirect:/dashboard/store/create", view);
         assertEquals("Błąd tworzenia", redirectAttributes.getFlashAttributes().get("errorMessage"));
         assertNull(redirectAttributes.getFlashAttributes().get("successMessage"));
+    }
+
+    private static Store storeWithCreatedAt(String storeId, String createdAt) {
+        Store store = new Store();
+        store.setStoreId(storeId);
+        store.setCreatedAt(createdAt);
+        return store;
+    }
+
+    @Test
+    void sortsStoresNewestFirstByDefaultWithNullsLast() {
+        // given
+        Store oldest = storeWithCreatedAt("old-store-1", "2026-01-01T10:00:00Z");
+        Store newest = storeWithCreatedAt("new-store-1", "2026-07-01T10:00:00Z");
+        Store legacy = storeWithCreatedAt("legacy-st-1", null);
+        when(storesRepository.findAll()).thenReturn(List.of(oldest, legacy, newest));
+        ConcurrentModel model = new ConcurrentModel();
+
+        // when
+        String view = controller.store("desc", model);
+
+        // then
+        assertEquals("stores", view);
+        assertEquals(List.of(newest, oldest, legacy), model.getAttribute("stores"));
+        assertEquals("desc", model.getAttribute("dir"));
+    }
+
+    @Test
+    void sortsStoresOldestFirstWhenAscendingRequested() {
+        // given
+        Store oldest = storeWithCreatedAt("old-store-1", "2026-01-01T10:00:00Z");
+        Store newest = storeWithCreatedAt("new-store-1", "2026-07-01T10:00:00Z");
+        Store legacy = storeWithCreatedAt("legacy-st-1", null);
+        when(storesRepository.findAll()).thenReturn(List.of(newest, legacy, oldest));
+        ConcurrentModel model = new ConcurrentModel();
+
+        // when
+        String view = controller.store("asc", model);
+
+        // then
+        assertEquals("stores", view);
+        assertEquals(List.of(oldest, newest, legacy), model.getAttribute("stores"));
+        assertEquals("asc", model.getAttribute("dir"));
+    }
+
+    @Test
+    void normalizesUnknownSortDirectionToDescending() {
+        // given
+        Store oldest = storeWithCreatedAt("old-store-1", "2026-01-01T10:00:00Z");
+        Store newest = storeWithCreatedAt("new-store-1", "2026-07-01T10:00:00Z");
+        when(storesRepository.findAll()).thenReturn(List.of(oldest, newest));
+        ConcurrentModel model = new ConcurrentModel();
+
+        // when
+        controller.store("bogus", model);
+
+        // then
+        assertEquals(List.of(newest, oldest), model.getAttribute("stores"));
+        assertEquals("desc", model.getAttribute("dir"));
     }
 }


### PR DESCRIPTION
## What

1. **Registration email lands in company details.** Store registration (both demo and production paths) now writes the registrant's email into `Store.billingDetails.email`, so `/dashboard/store/{storeId}/company-details` shows it immediately. Implemented via a new `ownerEmail` component on `CreateStoreRequest`: the new `registered(name, ownerEmail)` factory covers production registration, and `seeded(...)` derives the email from `DemoStoreMetadata.getOwnerEmail()`. `StoreCreationService` sets the email before the first save — no extra write, no version race. Manual store creation by super admin is unchanged (`bare(...)`, no email).

2. **Registration date column on the super-admin stores list.** `/dashboard/stores` gains a "Data rejestracji" column (`Store.createdAt`, shown as `yyyy-MM-dd`) with server-side sorting via `?dir=asc|desc` (default: newest first). Clickable header toggles direction; stores created before `createdAt` existed sort last with an empty cell.

## Notes

- Email is the only `BillingDetails` field pre-filled; the company-details edit form's `isProperlyFilled()` semantics are untouched. Checked all consumers of `Store.getBillingDetails()` — `PosOrderCreator` gates on `isProperlyFilled()`, so a partially-filled object behaves exactly like `null` did.
- Backward compatible: no migration, legacy stores with `null` `createdAt`/`billingDetails` behave as before.

## Tests

- `StoreCreationServiceTest`: email set from `registered(...)` and from demo metadata via `seeded(...)`; no `BillingDetails` without an email.
- `RegistrationServiceTest`: both paths pass the normalized email.
- `SuperAdminControllerTest`: desc default, asc on request, unknown `dir` normalized, nulls last.
- Full module suite: 862 tests passing.

## Migration (V008)

Existing demo stores registered before this change carry the email only in `demo.ownerEmail` and may lack `createdAt`. Mongock change unit `V008_BackfillStoreRegistrationData` backfills them on startup:
- missing `billingDetails` → set to `{email: demo.ownerEmail}`; existing `billingDetails` without an email → only the nested `billingDetails.email` is set (manually filled company data is never touched)
- missing `createdAt` → copied from `demo.createdAt`

Safety: point `UpdateItem` with `SET ... if_not_exists(...)` only (pattern of V005) — no full-item writes, no removes, nothing overwritten, idempotent; non-demo stores are skipped. No store can be lost or altered beyond the two missing attributes.

## Demo TTL

`app.registration.ttl-days=7` override in `application-demo.properties` — new demo registrations live 7 days (was 3). Existing stores keep their stored `demo.expiresAt` untouched: the cleanup job and the demo banner read the persisted value, so the property only affects new registrations. The registration-page notice is parameterized and updates automatically.